### PR TITLE
OdcmModel Refinements

### DIFF
--- a/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
@@ -9,9 +9,13 @@ namespace Vipr.Core.CodeModel
     {
         public bool IsAbstract { get; set; }
 
+        public OdcmClass Base { get; set; }
+
+        public IList<OdcmClass> Derived { get; private set; }
+
         public List<OdcmField> Key { get; private set; }
 
-        public OdcmClassKind Kind { get; private set; }
+        public OdcmClassKind Kind { get; set; }
 
         public List<OdcmField> Fields { get; private set; }
 
@@ -27,6 +31,7 @@ namespace Vipr.Core.CodeModel
             Properties = new List<OdcmProperty>();
             Methods = new List<OdcmMethod>();
             Key = new List<OdcmField>();
+            Derived = new List<OdcmClass>();
         }
 
         public override string AsReference()

--- a/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
@@ -9,6 +9,8 @@ namespace Vipr.Core.CodeModel
     {
         public bool IsAbstract { get; set; }
 
+        public bool IsOpen { get; set; }
+
         public OdcmClass Base { get; set; }
 
         public IList<OdcmClass> Derived { get; private set; }

--- a/src/Core/Vipr.Core/CodeModel/OdcmClassKind.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmClassKind.cs
@@ -7,6 +7,7 @@ namespace Vipr.Core.CodeModel
     {
         Complex,
         Entity,
+        MediaEntity,
         Service
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmEnum.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmEnum.cs
@@ -11,6 +11,8 @@ namespace Vipr.Core.CodeModel
 
         public List<OdcmEnumMember> Members { get; private set; }
 
+        public bool IsFlags { get; set; }
+
         public OdcmEnum(string name, string @namespace)
             : base(name, @namespace)
         {

--- a/src/Core/Vipr.Core/CodeModel/OdcmType.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmType.cs
@@ -10,15 +10,10 @@ namespace Vipr.Core.CodeModel
     {
         public string Namespace { get; set; }
 
-        public OdcmType Base { get; set; }
-
-        public IList<OdcmType> Derived { get; private set; }
-
         public OdcmType(string name, string @namespace)
             : base(name)
         {
             Namespace = @namespace;
-            Derived = new List<OdcmType>();
         }
 
         public string FullName

--- a/src/Core/Vipr.Core/IReader.cs
+++ b/src/Core/Vipr.Core/IReader.cs
@@ -9,7 +9,6 @@ namespace Vipr.Core
 {
     public interface IReader
     {
-        OdcmModel OdcmModel { get; }
         OdcmModel GenerateOdcmModel(IReadOnlyDictionary<string, string> serviceMetadata);
     }
 }

--- a/src/Core/Vipr.Core/OdcmExtensions.cs
+++ b/src/Core/Vipr.Core/OdcmExtensions.cs
@@ -17,7 +17,12 @@ namespace Vipr.Core
         public static IEnumerable<OdcmProperty> WhereIsNavigation(this IEnumerable<OdcmProperty> odcmProperties, bool isNavigation = true)
         {
             return odcmProperties
-                .Where(p => isNavigation == (p.Type is OdcmClass && ((OdcmClass)p.Type).Kind == OdcmClassKind.Entity));
+                .Where(
+                    p =>
+                        isNavigation ==
+                        (p.Type is OdcmClass &&
+                         (((OdcmClass) p.Type).Kind == OdcmClassKind.Entity ||
+                          ((OdcmClass) p.Type).Kind == OdcmClassKind.MediaEntity)));
         }
 
         public static IEnumerable<OdcmProperty> NavigationProperties(this OdcmClass odcmClass)

--- a/src/Core/Vipr.Core/OdcmExtensions.cs
+++ b/src/Core/Vipr.Core/OdcmExtensions.cs
@@ -43,10 +43,10 @@ namespace Vipr.Core
                 .Concat(odcmClass.Properties.Where(p => odcmClass.Key.Contains(p.Field)));
         }
 
-        public static IEnumerable<OdcmType> NestedDerivedTypes(this OdcmType odcmType)
+        public static IEnumerable<OdcmClass> NestedDerivedTypes(this OdcmClass odcmClass)
         {
-            var graph = new Queue<OdcmType>();
-            graph.Enqueue(odcmType);
+            var graph = new Queue<OdcmClass>();
+            graph.Enqueue(odcmClass);
             while (graph.Count > 0)
             {
                 var parent = graph.Dequeue();

--- a/src/Readers/ODataReader.v3/Reader.cs
+++ b/src/Readers/ODataReader.v3/Reader.cs
@@ -140,6 +140,7 @@ namespace ODataReader.v3
                     }
 
                     odcmClass.IsAbstract = complexType.IsAbstract;
+                    odcmClass.IsOpen = complexType.IsOpen;
 
                     if (complexType.BaseType != null)
                     {
@@ -177,6 +178,7 @@ namespace ODataReader.v3
                     }
 
                     odcmClass.IsAbstract = entityType.IsAbstract;
+                    odcmClass.IsOpen = entityType.IsOpen;
 
                     if (entityType.BaseType != null)
                     {

--- a/src/Readers/ODataReader.v3/Reader.cs
+++ b/src/Readers/ODataReader.v3/Reader.cs
@@ -17,425 +17,457 @@ namespace ODataReader.v3
 {
     public class Reader : IReader
     {
-        private IEdmModel _edmModel = null;
-        private const string _metadataKey = "$metadata";
-
-        public OdcmModel OdcmModel { get; private set; }
-
-        public Reader()
-        {
-
-        }
-
         public OdcmModel GenerateOdcmModel(IReadOnlyDictionary<string, string> serviceMetadata)
         {
-            if (serviceMetadata == null)
-                throw new ArgumentNullException("serviceMetadata");
-
-            if (!serviceMetadata.ContainsKey(_metadataKey))
-                throw new ArgumentException("Argument must contain value for key \"$metadata\"", "serviceMetadata");
-
-            var edmx = XElement.Parse(serviceMetadata[_metadataKey]);
-
-            IEnumerable<EdmError> errors;
-            if (!EdmxReader.TryParse(edmx.CreateReader(ReaderOptions.None), out _edmModel, out errors))
-            {
-                Debug.Assert(errors != null, "errors != null");
-                if (errors.FirstOrDefault() == null)
-                    throw new InvalidOperationException();
-                throw new InvalidOperationException(errors.FirstOrDefault().ErrorMessage);
-            }
-            OdcmModel = new OdcmModel(serviceMetadata);
-
-            WriteNamespaces();
-
-            return OdcmModel;
+            var daemon = new ReaderDaemon();
+            return daemon.GenerateOdcmModel(serviceMetadata);
         }
 
-        private void WriteNamespaces()
+        private class ReaderDaemon
         {
-            var declaredNamespaces = (from se in _edmModel.SchemaElements
-                                      select se.Namespace).Distinct();
-            foreach (var declaredNamespace in declaredNamespaces)
+            private const string MetadataKey = "$metadata";
+
+            private IEdmModel _edmModel = null;
+            private OdcmModel _odcmModel;
+
+            public OdcmModel GenerateOdcmModel(IReadOnlyDictionary<string, string> serviceMetadata)
             {
-                WriteNamespace(_edmModel, declaredNamespace);
-            }
-        }
+                if (serviceMetadata == null)
+                    throw new ArgumentNullException("serviceMetadata");
 
-        private void WriteNamespace(IEdmModel edmModel, string @namespace)
-        {
-            var namespaceElements = from se in edmModel.SchemaElements
-                                    where string.Equals(se.Namespace, @namespace)
-                                    select se;
+                if (!serviceMetadata.ContainsKey(MetadataKey))
+                    throw new ArgumentException("Argument must contain value for key \"$metadata\"", "serviceMetadata");
 
-            var types = from se in namespaceElements
-                        where se.SchemaElementKind == EdmSchemaElementKind.TypeDefinition
-                        select se as IEdmType;
+                var edmx = XElement.Parse(serviceMetadata[MetadataKey]);
 
-            var complexTypes = from se in types
-                               where se.TypeKind == EdmTypeKind.Complex
-                               select se as IEdmComplexType;
-
-            var entityTypes = from se in types
-                              where se.TypeKind == EdmTypeKind.Entity
-                              select se as IEdmEntityType;
-
-            var enumTypes = from se in types
-                            where se.TypeKind == EdmTypeKind.Enum
-                            select se as IEdmEnumType;
-
-            var entityContainers = from se in namespaceElements
-                                   where se.SchemaElementKind == EdmSchemaElementKind.EntityContainer
-                                   select se as IEdmEntityContainer;
-
-            var boundFunctions = from se in
-                                     (from ec in entityContainers
-                                      select ec.Elements).SelectMany(v => v)
-                                 where se.ContainerElementKind == EdmContainerElementKind.FunctionImport && ((IEdmFunctionImport)se).IsBindable
-                                 select se as IEdmFunctionImport;
-
-            Console.WriteLine(@namespace);
-
-            foreach (var enumType in enumTypes)
-            {
-                OdcmEnum odcmEnum;
-                if (!OdcmModel.TryResolveType(enumType.Name, enumType.Namespace, out odcmEnum))
+                IEnumerable<EdmError> errors;
+                if (!EdmxReader.TryParse(edmx.CreateReader(ReaderOptions.None), out _edmModel, out errors))
                 {
-                    odcmEnum = new OdcmEnum(enumType.Name, enumType.Namespace);
-                    odcmEnum.UnderlyingType = (OdcmPrimitiveType)ResolveType(enumType.UnderlyingType.Name, enumType.UnderlyingType.Namespace, TypeKind.Primitive);
-                    OdcmModel.AddType(odcmEnum);
+                    Debug.Assert(errors != null, "errors != null");
+
+                    if (errors.FirstOrDefault() == null)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    throw new InvalidOperationException(errors.FirstOrDefault().ErrorMessage);
                 }
 
-                foreach (var enumMember in enumType.Members)
+                _odcmModel = new OdcmModel(serviceMetadata);
+
+                WriteNamespaces();
+
+                return _odcmModel;
+            }
+
+            private void WriteNamespaces()
+            {
+                var declaredNamespaces = (from se in _edmModel.SchemaElements
+                    select se.Namespace).Distinct();
+                foreach (var declaredNamespace in declaredNamespaces)
                 {
-                    odcmEnum.Members.Add(new OdcmEnumMember(enumMember.Name)
+                    WriteNamespace(_edmModel, declaredNamespace);
+                }
+            }
+
+            private void WriteNamespace(IEdmModel edmModel, string @namespace)
+            {
+                var namespaceElements = from se in edmModel.SchemaElements
+                    where string.Equals(se.Namespace, @namespace)
+                    select se;
+
+                var types = from se in namespaceElements
+                    where se.SchemaElementKind == EdmSchemaElementKind.TypeDefinition
+                    select se as IEdmType;
+
+                var complexTypes = from se in types
+                    where se.TypeKind == EdmTypeKind.Complex
+                    select se as IEdmComplexType;
+
+                var entityTypes = from se in types
+                    where se.TypeKind == EdmTypeKind.Entity
+                    select se as IEdmEntityType;
+
+                var enumTypes = from se in types
+                    where se.TypeKind == EdmTypeKind.Enum
+                    select se as IEdmEnumType;
+
+                var entityContainers = from se in namespaceElements
+                    where se.SchemaElementKind == EdmSchemaElementKind.EntityContainer
+                    select se as IEdmEntityContainer;
+
+                var boundFunctions = from se in
+                    (from ec in entityContainers
+                        select ec.Elements).SelectMany(v => v)
+                    where
+                        se.ContainerElementKind == EdmContainerElementKind.FunctionImport &&
+                        ((IEdmFunctionImport) se).IsBindable
+                    select se as IEdmFunctionImport;
+
+                Console.WriteLine(@namespace);
+
+                foreach (var enumType in enumTypes)
+                {
+                    OdcmEnum odcmEnum;
+                    if (!_odcmModel.TryResolveType(enumType.Name, enumType.Namespace, out odcmEnum))
                     {
-                        Value = ((EdmIntegerConstant)enumMember.Value).Value
+                        odcmEnum = new OdcmEnum(enumType.Name, enumType.Namespace);
+                        _odcmModel.AddType(odcmEnum);
+                    }
+
+                    odcmEnum.UnderlyingType =
+                        (OdcmPrimitiveType)
+                            ResolveType(enumType.UnderlyingType.Name, enumType.UnderlyingType.Namespace,
+                                TypeKind.Primitive);
+                    odcmEnum.IsFlags = enumType.IsFlags;
+
+                    foreach (var enumMember in enumType.Members)
+                    {
+                        odcmEnum.Members.Add(new OdcmEnumMember(enumMember.Name)
+                        {
+                            Value = ((EdmIntegerConstant) enumMember.Value).Value
+                        });
+                    }
+                }
+
+                foreach (var complexType in complexTypes)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(complexType.Name, complexType.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(complexType.Name, complexType.Namespace, OdcmClassKind.Complex);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    odcmClass.IsAbstract = complexType.IsAbstract;
+
+                    if (complexType.BaseType != null)
+                    {
+                        OdcmClass baseClass;
+                        if (
+                            !_odcmModel.TryResolveType(((IEdmSchemaElement) complexType.BaseType).Name,
+                                ((IEdmSchemaElement) complexType.BaseType).Namespace, out baseClass))
+                        {
+                            baseClass = new OdcmClass(((IEdmSchemaElement) complexType.BaseType).Name,
+                                ((IEdmSchemaElement) complexType.BaseType).Namespace, OdcmClassKind.Complex);
+                            _odcmModel.AddType(baseClass);
+                        }
+                        odcmClass.Base = baseClass;
+                        if (!baseClass.Derived.Contains(odcmClass))
+                            baseClass.Derived.Add(odcmClass);
+                    }
+
+                    var structuralProperties = from element in complexType.Properties()
+                        where element.PropertyKind == EdmPropertyKind.Structural
+                        select element as IEdmStructuralProperty;
+                    foreach (var structuralProperty in structuralProperties)
+                    {
+                        OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
+                        WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
+                    }
+                }
+
+                foreach (var entityType in entityTypes)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(entityType.Name, entityType.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(entityType.Name, entityType.Namespace, OdcmClassKind.Entity);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    odcmClass.IsAbstract = entityType.IsAbstract;
+
+                    if (entityType.BaseType != null)
+                    {
+                        OdcmClass baseClass;
+                        if (
+                            !_odcmModel.TryResolveType(((IEdmSchemaElement) entityType.BaseType).Name,
+                                ((IEdmSchemaElement) entityType.BaseType).Namespace, out baseClass))
+                        {
+                            baseClass = new OdcmClass(((IEdmSchemaElement) entityType.BaseType).Name,
+                                ((IEdmSchemaElement) entityType.BaseType).Namespace, OdcmClassKind.Entity);
+                            _odcmModel.AddType(baseClass);
+                        }
+
+                        odcmClass.Base = baseClass;
+
+                        if (!baseClass.Derived.Contains(odcmClass))
+                            baseClass.Derived.Add(odcmClass);
+                    }
+
+                    var structuralProperties = from element in entityType.Properties()
+                        where element.PropertyKind == EdmPropertyKind.Structural
+                        select element as IEdmStructuralProperty;
+                    foreach (var structuralProperty in structuralProperties)
+                    {
+                        OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
+                        WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
+                    }
+
+                    var navigationProperties = from element in entityType.Properties()
+                        where element.PropertyKind == EdmPropertyKind.Navigation
+                        select element as IEdmNavigationProperty;
+                    foreach (var navigationProperty in navigationProperties)
+                    {
+                        OdcmField odcmField = WriteNavigationField(odcmClass, navigationProperty);
+                        WriteNavigationProperty(odcmClass, odcmField, navigationProperty);
+                    }
+
+                    foreach (IEdmStructuralProperty keyProperty in entityType.Key())
+                    {
+                        var property = FindProperty(odcmClass, keyProperty);
+                        if (property != null)
+                        {
+                            // The properties that compose the key MUST be non-nullable.
+                            property.IsNullable = false;
+                        }
+
+                        odcmClass.Key.Add(FindField(odcmClass, keyProperty));
+                    }
+
+                    var entityTypeFunctions = from se in boundFunctions
+                        where IsFunctionBound(se, entityType)
+                        select se;
+                    foreach (var function in entityTypeFunctions)
+                    {
+                        WriteMethod(odcmClass, function);
+                    }
+                }
+
+                foreach (var entityContainer in entityContainers)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(entityContainer.Name, entityContainer.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(entityContainer.Name, entityContainer.Namespace, OdcmClassKind.Service);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    var entitySets = from se in entityContainer.Elements
+                        where se.ContainerElementKind == EdmContainerElementKind.EntitySet
+                        select se as IEdmEntitySet;
+                    foreach (var entitySet in entitySets)
+                    {
+                        OdcmField odcmField = WriteField(odcmClass, entitySet);
+                        WriteProperty(odcmClass, odcmField, entitySet);
+                    }
+
+                    var functionImports = from se in entityContainer.Elements
+                        where
+                            se.ContainerElementKind == EdmContainerElementKind.FunctionImport &&
+                            !((IEdmFunctionImport) se).IsBindable
+                        select se as IEdmFunctionImport;
+                    foreach (var functionImport in functionImports)
+                    {
+                        WriteMethod(odcmClass, functionImport);
+                    }
+                }
+            }
+
+            private bool IsFunctionBound(IEdmFunctionImport function, IEdmEntityType entityType)
+            {
+                var bindingParameterType = function.Parameters.First().Type;
+
+                return (bindingParameterType.Definition == entityType) ||
+                       (bindingParameterType.IsCollection() &&
+                        bindingParameterType.AsCollection().ElementType().Definition == entityType);
+            }
+
+            private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmEntitySet entitySet)
+            {
+                OdcmProperty odcmProperty = new OdcmProperty(entitySet.Name);
+                odcmProperty.Class = odcmClass;
+                odcmClass.Properties.Add(odcmProperty);
+
+                odcmProperty.Field = odcmField;
+                odcmProperty.Type = odcmField.Type;
+            }
+
+            private OdcmField WriteField(OdcmClass odcmClass, IEdmEntitySet entitySet)
+            {
+                OdcmField odcmField = new OdcmField("_" + entitySet.Name);
+                odcmField.Class = odcmClass;
+                odcmClass.Fields.Add(odcmField);
+
+                odcmField.Type = ResolveType(entitySet.ElementType.Name, entitySet.ElementType.Namespace,
+                    TypeKind.Entity);
+
+                odcmField.IsCollection = true;
+                odcmField.IsLink = true;
+
+                return odcmField;
+            }
+
+            private OdcmField FindField(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
+            {
+                foreach (OdcmField field in odcmClass.Fields)
+                {
+                    if (field.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return field;
+                    }
+                }
+
+                return null;
+            }
+
+            private OdcmProperty FindProperty(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
+            {
+                foreach (OdcmProperty property in odcmClass.Properties)
+                {
+                    if (property.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return property;
+                    }
+                }
+
+                return null;
+            }
+
+            private void WriteMethod(OdcmClass odcmClass, IEdmFunctionImport operation)
+            {
+                IEnumerable<IEdmFunctionParameter> parameters = operation.IsBindable
+                    ? (from parameter in operation.Parameters
+                        where parameter != operation.Parameters.First()
+                        select parameter)
+                    : (operation.Parameters);
+
+                bool isBoundToCollection = operation.IsBindable && operation.Parameters.First().Type.IsCollection();
+
+                var odcmMethod = new OdcmMethod(operation.Name)
+                {
+                    Verbs = operation.IsSideEffecting ? OdcmAllowedVerbs.Post : OdcmAllowedVerbs.Any,
+                    IsBoundToCollection = isBoundToCollection,
+                    IsComposable = operation.IsComposable,
+                    Class = odcmClass
+                };
+
+                odcmClass.Methods.Add(odcmMethod);
+
+                if (operation.ReturnType != null)
+                {
+                    odcmMethod.ReturnType = ResolveType(operation.ReturnType);
+                    odcmMethod.IsCollection = operation.ReturnType.IsCollection();
+                }
+
+                var callingConvention =
+                    operation.IsSideEffecting
+                        ? OdcmCallingConvention.InHttpMessageBody
+                        : OdcmCallingConvention.InHttpRequestUri;
+
+                foreach (var parameter in parameters)
+                {
+                    odcmMethod.Parameters.Add(new OdcmParameter(parameter.Name)
+                    {
+                        CallingConvention = callingConvention,
+                        Type = ResolveType(parameter.Type),
+                        IsCollection = parameter.Type.IsCollection(),
+                        IsNullable = parameter.Type.IsNullable
                     });
                 }
             }
 
-            foreach (var complexType in complexTypes)
+            private void WriteNavigationProperty(OdcmClass odcmClass, OdcmField odcmField,
+                IEdmNavigationProperty navigationProperty)
             {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(complexType.Name, complexType.Namespace, out odcmClass))
+                WriteProperty(odcmClass, odcmField, navigationProperty);
+            }
+
+            private void WriteStructuralProperty(OdcmClass odcmClass, OdcmField odcmField,
+                IEdmStructuralProperty structuralProperty)
+            {
+                WriteProperty(odcmClass, odcmField, structuralProperty);
+            }
+
+            private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmProperty property)
+            {
+                OdcmProperty odcmProperty = new OdcmProperty(property.Name);
+                odcmProperty.Class = odcmClass;
+                odcmProperty.IsNullable = property.Type.IsNullable;
+                odcmClass.Properties.Add(odcmProperty);
+
+                odcmProperty.Field = odcmField;
+            }
+
+            private OdcmField WriteNavigationField(OdcmClass odcmClass, IEdmNavigationProperty navigationProperty)
+            {
+                OdcmField odcmField = WriteField(odcmClass, navigationProperty);
+
+                odcmField.ContainsTarget = navigationProperty.ContainsTarget;
+                odcmField.IsLink = true;
+
+                return odcmField;
+            }
+
+            private OdcmField WriteStructuralField(OdcmClass odcmClass, IEdmStructuralProperty structuralProperty)
+            {
+                return WriteField(odcmClass, structuralProperty);
+            }
+
+            private OdcmField WriteField(OdcmClass odcmClass, IEdmProperty property)
+            {
+                OdcmField odcmField = new OdcmField(property.Name);
+                odcmField.Class = odcmClass;
+                odcmClass.Fields.Add(odcmField);
+
+                odcmField.Type = ResolveType(property.Type);
+                odcmField.IsCollection = property.Type.IsCollection();
+
+                return odcmField;
+            }
+
+            private OdcmType ResolveType(IEdmTypeReference realizedType)
+            {
+                if (realizedType.IsCollection())
                 {
-                    odcmClass = new OdcmClass(complexType.Name, complexType.Namespace, OdcmClassKind.Complex);
-                    OdcmModel.AddType(odcmClass);
+                    realizedType = realizedType.AsCollection().ElementType();
                 }
 
-                odcmClass.IsAbstract = complexType.IsAbstract;
+                if (realizedType.IsComplex())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Complex);
 
-                if (complexType.BaseType != null)
+                if (realizedType.IsEntity())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Entity);
+
+                if (realizedType.IsEnum())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Enum);
+
+                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Primitive);
+            }
+
+            private OdcmType ResolveType(IEdmSchemaElement realizedSchemaElement, TypeKind kind)
+            {
+                return ResolveType(realizedSchemaElement.Name, realizedSchemaElement.Namespace, kind);
+            }
+
+            private OdcmType ResolveType(string name, string @namespace, TypeKind kind)
+            {
+                OdcmType type;
+
+                if (!_odcmModel.TryResolveType(name, @namespace, out type))
                 {
-                    OdcmClass baseClass;
-                    if (!OdcmModel.TryResolveType(((IEdmSchemaElement)complexType.BaseType).Name, ((IEdmSchemaElement)complexType.BaseType).Namespace, out baseClass))
+                    switch (kind)
                     {
-                        baseClass = new OdcmClass(((IEdmSchemaElement)complexType.BaseType).Name, ((IEdmSchemaElement)complexType.BaseType).Namespace, OdcmClassKind.Complex);
-                        OdcmModel.AddType(baseClass);
-                    }
-                    odcmClass.Base = baseClass;
-                    if(!baseClass.Derived.Contains(odcmClass))
-                        baseClass.Derived.Add(odcmClass);
-                }
-
-                var structuralProperties = from element in complexType.Properties()
-                                           where element.PropertyKind == EdmPropertyKind.Structural
-                                           select element as IEdmStructuralProperty;
-                foreach (var structuralProperty in structuralProperties)
-                {
-                    OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
-                    WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
-                }
-            }
-
-            foreach (var entityType in entityTypes)
-            {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(entityType.Name, entityType.Namespace, out odcmClass))
-                {
-                    odcmClass = new OdcmClass(entityType.Name, entityType.Namespace, OdcmClassKind.Entity);
-                    OdcmModel.AddType(odcmClass);
-                }
-
-                odcmClass.IsAbstract = entityType.IsAbstract;
-
-                if (entityType.BaseType != null)
-                {
-                    OdcmClass baseClass;
-                    if (!OdcmModel.TryResolveType(((IEdmSchemaElement)entityType.BaseType).Name, ((IEdmSchemaElement)entityType.BaseType).Namespace, out baseClass))
-                    {
-                        baseClass = new OdcmClass(((IEdmSchemaElement)entityType.BaseType).Name, ((IEdmSchemaElement)entityType.BaseType).Namespace, OdcmClassKind.Entity);
-                        OdcmModel.AddType(baseClass);
-                    }
-                    odcmClass.Base = baseClass;
-                    if(!baseClass.Derived.Contains(odcmClass))
-                        baseClass.Derived.Add(odcmClass);
-                }
-
-                var structuralProperties = from element in entityType.Properties()
-                                           where element.PropertyKind == EdmPropertyKind.Structural
-                                           select element as IEdmStructuralProperty;
-                foreach (var structuralProperty in structuralProperties)
-                {
-                    OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
-                    WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
-                }
-
-                var navigationProperties = from element in entityType.Properties()
-                                           where element.PropertyKind == EdmPropertyKind.Navigation
-                                           select element as IEdmNavigationProperty;
-                foreach (var navigationProperty in navigationProperties)
-                {
-                    OdcmField odcmField = WriteNavigationField(odcmClass, navigationProperty);
-                    WriteNavigationProperty(odcmClass, odcmField, navigationProperty);
-                }
-
-                foreach (IEdmStructuralProperty keyProperty in entityType.Key())
-                {
-                    var property = FindProperty(odcmClass, keyProperty);
-                    if (property != null)
-                    {
-                        // The properties that compose the key MUST be non-nullable.
-                        property.IsNullable = false;
+                        case TypeKind.Complex:
+                            type = new OdcmClass(name, @namespace, OdcmClassKind.Complex);
+                            break;
+                        case TypeKind.Entity:
+                            type = new OdcmClass(name, @namespace, OdcmClassKind.Entity);
+                            break;
+                        case TypeKind.Enum:
+                            type = new OdcmEnum(name, @namespace);
+                            break;
+                        case TypeKind.Primitive:
+                            type = new OdcmPrimitiveType(name, @namespace);
+                            break;
                     }
 
-                    odcmClass.Key.Add(FindField(odcmClass, keyProperty));
+                    _odcmModel.AddType(type);
                 }
 
-                var entityTypeFunctions = from se in boundFunctions
-                                          where IsFunctionBound(se, entityType)
-                                          select se;
-                foreach (var function in entityTypeFunctions)
-                {
-                    WriteMethod(odcmClass, function);
-                }
+                return type;
             }
-
-            foreach (var entityContainer in entityContainers)
-            {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(entityContainer.Name, entityContainer.Namespace, out odcmClass))
-                {
-                    odcmClass = new OdcmClass(entityContainer.Name, entityContainer.Namespace, OdcmClassKind.Service);
-                    OdcmModel.AddType(odcmClass);
-                }
-
-                var entitySets = from se in entityContainer.Elements
-                                 where se.ContainerElementKind == EdmContainerElementKind.EntitySet
-                                 select se as IEdmEntitySet;
-                foreach (var entitySet in entitySets)
-                {
-                    OdcmField odcmField = WriteField(odcmClass, entitySet);
-                    WriteProperty(odcmClass, odcmField, entitySet);
-                }
-
-                var functionImports = from se in entityContainer.Elements
-                                      where se.ContainerElementKind == EdmContainerElementKind.FunctionImport && !((IEdmFunctionImport)se).IsBindable
-                                      select se as IEdmFunctionImport;
-                foreach (var functionImport in functionImports)
-                {
-                    WriteMethod(odcmClass, functionImport);
-                }
-            }
-        }
-
-        private bool IsFunctionBound(IEdmFunctionImport function, IEdmEntityType entityType)
-        {
-            var bindingParameterType = function.Parameters.First().Type;
-
-            return (bindingParameterType.Definition == entityType) ||
-                (bindingParameterType.IsCollection() && bindingParameterType.AsCollection().ElementType().Definition == entityType);
-        }
-
-        private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmEntitySet entitySet)
-        {
-            OdcmProperty odcmProperty = new OdcmProperty(entitySet.Name);
-            odcmProperty.Class = odcmClass;
-            odcmClass.Properties.Add(odcmProperty);
-
-            odcmProperty.Field = odcmField;
-            odcmProperty.Type = odcmField.Type;
-        }
-
-        private OdcmField WriteField(OdcmClass odcmClass, IEdmEntitySet entitySet)
-        {
-            OdcmField odcmField = new OdcmField("_" + entitySet.Name);
-            odcmField.Class = odcmClass;
-            odcmClass.Fields.Add(odcmField);
-
-            odcmField.Type = ResolveType(entitySet.ElementType.Name, entitySet.ElementType.Namespace, TypeKind.Entity);
-
-            odcmField.IsCollection = true;
-            odcmField.IsLink = true;
-
-            return odcmField;
-        }
-
-        private OdcmField FindField(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
-        {
-            foreach (OdcmField field in odcmClass.Fields)
-            {
-                if (field.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return field;
-                }
-            }
-
-            return null;
-        }
-
-        private OdcmProperty FindProperty(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
-        {
-            foreach (OdcmProperty property in odcmClass.Properties)
-            {
-                if (property.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return property;
-                }
-            }
-
-            return null;
-        }
-
-        private void WriteMethod(OdcmClass odcmClass, IEdmFunctionImport operation)
-        {
-            IEnumerable<IEdmFunctionParameter> parameters = operation.IsBindable
-                ? (from parameter in operation.Parameters where parameter != operation.Parameters.First() select parameter)
-                : (operation.Parameters);
-
-            bool isBoundToCollection = operation.IsBindable && operation.Parameters.First().Type.IsCollection();
-
-            var odcmMethod = new OdcmMethod(operation.Name)
-            {
-                Verbs = operation.IsSideEffecting ? OdcmAllowedVerbs.Post : OdcmAllowedVerbs.Any,
-                IsBoundToCollection = isBoundToCollection,
-                IsComposable = operation.IsComposable,
-                Class = odcmClass
-            };
-
-            odcmClass.Methods.Add(odcmMethod);
-
-            if (operation.ReturnType != null)
-            {
-                odcmMethod.ReturnType = ResolveType(operation.ReturnType);
-                odcmMethod.IsCollection = operation.ReturnType.IsCollection();
-            }
-
-            var callingConvention =
-                operation.IsSideEffecting
-                    ? OdcmCallingConvention.InHttpMessageBody
-                    : OdcmCallingConvention.InHttpRequestUri;
-
-            foreach (var parameter in parameters)
-            {
-                odcmMethod.Parameters.Add(new OdcmParameter(parameter.Name)
-                {
-                    CallingConvention = callingConvention,
-                    Type = ResolveType(parameter.Type),
-                    IsCollection = parameter.Type.IsCollection(),
-                    IsNullable = parameter.Type.IsNullable
-                });
-            }
-        }
-
-        private void WriteNavigationProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmNavigationProperty navigationProperty)
-        {
-            WriteProperty(odcmClass, odcmField, navigationProperty);
-        }
-
-        private void WriteStructuralProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmStructuralProperty structuralProperty)
-        {
-            WriteProperty(odcmClass, odcmField, structuralProperty);
-        }
-
-        private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmProperty property)
-        {
-            OdcmProperty odcmProperty = new OdcmProperty(property.Name);
-            odcmProperty.Class = odcmClass;
-            odcmProperty.IsNullable = property.Type.IsNullable;
-            odcmClass.Properties.Add(odcmProperty);
-
-            odcmProperty.Field = odcmField;
-        }
-
-        private OdcmField WriteNavigationField(OdcmClass odcmClass, IEdmNavigationProperty navigationProperty)
-        {
-            OdcmField odcmField = WriteField(odcmClass, navigationProperty);
-
-            odcmField.ContainsTarget = navigationProperty.ContainsTarget;
-            odcmField.IsLink = true;
-
-            return odcmField;
-        }
-
-        private OdcmField WriteStructuralField(OdcmClass odcmClass, IEdmStructuralProperty structuralProperty)
-        {
-            return WriteField(odcmClass, structuralProperty);
-        }
-
-        private OdcmField WriteField(OdcmClass odcmClass, IEdmProperty property)
-        {
-            OdcmField odcmField = new OdcmField(property.Name);
-            odcmField.Class = odcmClass;
-            odcmClass.Fields.Add(odcmField);
-
-            odcmField.Type = ResolveType(property.Type);
-            odcmField.IsCollection = property.Type.IsCollection();
-
-            return odcmField;
-        }
-
-        private OdcmType ResolveType(IEdmTypeReference realizedType)
-        {
-            if (realizedType.IsCollection())
-            {
-                realizedType = realizedType.AsCollection().ElementType();
-            }
-
-            if (realizedType.IsComplex())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Complex);
-
-            if (realizedType.IsEntity())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Entity);
-
-            if (realizedType.IsEnum())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Enum);
-
-            return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Primitive);
-        }
-
-        private OdcmType ResolveType(IEdmSchemaElement realizedSchemaElement, TypeKind kind)
-        {
-            return ResolveType(realizedSchemaElement.Name, realizedSchemaElement.Namespace, kind);
-        }
-
-        private OdcmType ResolveType(string name, string @namespace, TypeKind kind)
-        {
-            OdcmType type;
-
-            if (!OdcmModel.TryResolveType(name, @namespace, out type))
-            {
-                switch (kind)
-                {
-                    case TypeKind.Complex:
-                        type = new OdcmClass(name, @namespace, OdcmClassKind.Complex);
-                        break;
-                    case TypeKind.Entity:
-                        type = new OdcmClass(name, @namespace, OdcmClassKind.Entity);
-                        break;
-                    case TypeKind.Enum:
-                        type = new OdcmEnum(name, @namespace);
-                        break;
-                    case TypeKind.Primitive:
-                        type = new OdcmPrimitiveType(name, @namespace);
-                        break;
-                }
-
-                OdcmModel.AddType(type);
-            }
-
-            return type;
         }
     }
 
@@ -443,7 +475,9 @@ namespace ODataReader.v3
     {
         public static string FullTypeName(this IEdmTypeReference typeReference, string @namespace = "")
         {
-            string result = (typeReference.IsCollection()) ? "Collection(" + typeReference.AsCollection().ElementType().FullName() + ")" : typeReference.FullName();
+            string result = (typeReference.IsCollection())
+                ? "Collection(" + typeReference.AsCollection().ElementType().FullName() + ")"
+                : typeReference.FullName();
 
             if (!string.IsNullOrEmpty(@namespace))
             {

--- a/src/Readers/ODataReader.v4/Reader.cs
+++ b/src/Readers/ODataReader.v4/Reader.cs
@@ -17,465 +17,505 @@ namespace ODataReader.v4
 {
     public class Reader : IReader
     {
-        private IEdmModel _edmModel = null;
-        private const string _metadataKey = "$metadata";
-
-        public OdcmModel OdcmModel { get; private set; }
-
         public OdcmModel GenerateOdcmModel(IReadOnlyDictionary<string, string> serviceMetadata)
         {
-            if (serviceMetadata == null)
-                throw new ArgumentNullException("serviceMetadata");
-
-            if (!serviceMetadata.ContainsKey(_metadataKey))
-                throw new ArgumentException("Argument must contain value for key \"$metadata\"", "serviceMetadata");
-
-            var edmx = XElement.Parse(serviceMetadata[_metadataKey]);
-
-            IEnumerable<EdmError> errors;
-            if (!EdmxReader.TryParse(edmx.CreateReader(ReaderOptions.None), out _edmModel, out errors))
-            {
-                Debug.Assert(errors != null, "errors != null");
-                if (errors.FirstOrDefault() == null)
-                    throw new InvalidOperationException();
-                throw new InvalidOperationException(errors.FirstOrDefault().ErrorMessage);
-            }
-            OdcmModel = new OdcmModel(serviceMetadata);
-
-            WriteNamespaces();
-
-            return OdcmModel;
+            var daemon = new ReaderDaemon();
+            return daemon.GenerateOdcmModel(serviceMetadata);
         }
 
-        private void WriteNamespaces()
+        private class ReaderDaemon
         {
-            foreach (var declaredNamespace in _edmModel.DeclaredNamespaces)
+            private const string MetadataKey = "$metadata";
+
+            private IEdmModel _edmModel = null;
+            private OdcmModel _odcmModel;
+
+            public OdcmModel GenerateOdcmModel(IReadOnlyDictionary<string, string> serviceMetadata)
             {
-                WriteNamespace(_edmModel, declaredNamespace);
-            }
-        }
+                if (serviceMetadata == null)
+                    throw new ArgumentNullException("serviceMetadata");
 
-        private void WriteNamespace(IEdmModel edmModel, string @namespace)
-        {
-            var namespaceElements = from elements in edmModel.SchemaElements
-                                    where string.Equals(elements.Namespace, @namespace)
-                                    select elements;
+                if (!serviceMetadata.ContainsKey(MetadataKey))
+                    throw new ArgumentException("Argument must contain value for key \"$metadata\"", "serviceMetadata");
 
-            var types = from element in namespaceElements
-                        where element.SchemaElementKind == EdmSchemaElementKind.TypeDefinition
-                        select element as IEdmType;
-            var complexTypes = from element in types
-                               where element.TypeKind == EdmTypeKind.Complex
-                               select element as IEdmComplexType;
-            var entityTypes = from element in types
-                              where element.TypeKind == EdmTypeKind.Entity
-                              select element as IEdmEntityType;
-            var enumTypes = from elements in types
-                            where elements.TypeKind == EdmTypeKind.Enum
-                            select elements as IEdmEnumType;
+                var edmx = XElement.Parse(serviceMetadata[MetadataKey]);
 
-            var entityContainers = from element in namespaceElements
-                                   where element.SchemaElementKind == EdmSchemaElementKind.EntityContainer
-                                   select element as IEdmEntityContainer;
-
-            var actions = from element in namespaceElements
-                          where element.SchemaElementKind == EdmSchemaElementKind.Action && ((IEdmAction)element).IsBound
-                          select element as IEdmAction;
-
-            var functions = from element in namespaceElements
-                            where element.SchemaElementKind == EdmSchemaElementKind.Function && ((IEdmFunction)element).IsBound
-                            select element as IEdmFunction;
-
-            foreach (var enumType in enumTypes)
-            {
-                OdcmEnum odcmEnum;
-                if (!OdcmModel.TryResolveType(enumType.Name, enumType.Namespace, out odcmEnum))
+                IEnumerable<EdmError> errors;
+                if (!EdmxReader.TryParse(edmx.CreateReader(ReaderOptions.None), out _edmModel, out errors))
                 {
-                    odcmEnum = new OdcmEnum(enumType.Name, enumType.Namespace);
-                    odcmEnum.UnderlyingType = (OdcmPrimitiveType)ResolveType(enumType.UnderlyingType.Name, enumType.UnderlyingType.Namespace, TypeKind.Primitive);
-                    OdcmModel.AddType(odcmEnum);
+                    Debug.Assert(errors != null, "errors != null");
+                    
+                    if (errors.FirstOrDefault() == null)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    throw new InvalidOperationException(errors.FirstOrDefault().ErrorMessage);
                 }
 
-                foreach (var enumMember in enumType.Members)
+                _odcmModel = new OdcmModel(serviceMetadata);
+
+                WriteNamespaces();
+
+                return _odcmModel;
+            }
+
+            private void WriteNamespaces()
+            {
+                foreach (var declaredNamespace in _edmModel.DeclaredNamespaces)
                 {
-                    odcmEnum.Members.Add(new OdcmEnumMember(enumMember.Name)
+                    WriteNamespace(_edmModel, declaredNamespace);
+                }
+            }
+
+            private void WriteNamespace(IEdmModel edmModel, string @namespace)
+            {
+                var namespaceElements = from elements in edmModel.SchemaElements
+                    where string.Equals(elements.Namespace, @namespace)
+                    select elements;
+
+                var types = from element in namespaceElements
+                    where element.SchemaElementKind == EdmSchemaElementKind.TypeDefinition
+                    select element as IEdmType;
+                var complexTypes = from element in types
+                    where element.TypeKind == EdmTypeKind.Complex
+                    select element as IEdmComplexType;
+                var entityTypes = from element in types
+                    where element.TypeKind == EdmTypeKind.Entity
+                    select element as IEdmEntityType;
+                var enumTypes = from elements in types
+                    where elements.TypeKind == EdmTypeKind.Enum
+                    select elements as IEdmEnumType;
+
+                var entityContainers = from element in namespaceElements
+                    where element.SchemaElementKind == EdmSchemaElementKind.EntityContainer
+                    select element as IEdmEntityContainer;
+
+                var actions = from element in namespaceElements
+                    where element.SchemaElementKind == EdmSchemaElementKind.Action && ((IEdmAction) element).IsBound
+                    select element as IEdmAction;
+
+                var functions = from element in namespaceElements
+                    where element.SchemaElementKind == EdmSchemaElementKind.Function && ((IEdmFunction) element).IsBound
+                    select element as IEdmFunction;
+
+                foreach (var enumType in enumTypes)
+                {
+                    OdcmEnum odcmEnum;
+                    if (!_odcmModel.TryResolveType(enumType.Name, enumType.Namespace, out odcmEnum))
                     {
-                        Value = ((EdmIntegerConstant)enumMember.Value).Value
+                        odcmEnum = new OdcmEnum(enumType.Name, enumType.Namespace);
+                        _odcmModel.AddType(odcmEnum);
+                    }
+
+                    odcmEnum.UnderlyingType =
+                        (OdcmPrimitiveType)
+                            ResolveType(enumType.UnderlyingType.Name, enumType.UnderlyingType.Namespace,
+                                TypeKind.Primitive);
+                    odcmEnum.IsFlags = enumType.IsFlags;
+
+                    foreach (var enumMember in enumType.Members)
+                    {
+                        odcmEnum.Members.Add(new OdcmEnumMember(enumMember.Name)
+                        {
+                            Value = ((EdmIntegerConstant) enumMember.Value).Value
+                        });
+                    }
+                }
+
+                foreach (var complexType in complexTypes)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(complexType.Name, complexType.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(complexType.Name, complexType.Namespace, OdcmClassKind.Complex);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    odcmClass.IsAbstract = complexType.IsAbstract;
+
+                    if (complexType.BaseType != null)
+                    {
+                        OdcmClass baseClass;
+                        if (
+                            !_odcmModel.TryResolveType(((IEdmSchemaElement) complexType.BaseType).Name,
+                                ((IEdmSchemaElement) complexType.BaseType).Namespace, out baseClass))
+                        {
+                            baseClass = new OdcmClass(((IEdmSchemaElement) complexType.BaseType).Name,
+                                ((IEdmSchemaElement) complexType.BaseType).Namespace, OdcmClassKind.Complex);
+                            _odcmModel.AddType(baseClass);
+                        }
+                        odcmClass.Base = baseClass;
+                        if (!baseClass.Derived.Contains(odcmClass))
+                            baseClass.Derived.Add(odcmClass);
+                    }
+
+                    var structuralProperties = from element in complexType.Properties()
+                        where element.PropertyKind == EdmPropertyKind.Structural &&
+                              element.DeclaringType == (IEdmStructuredType) complexType
+                        select element as IEdmStructuralProperty;
+                    foreach (var structuralProperty in structuralProperties)
+                    {
+                        OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
+                        WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
+                    }
+                }
+
+                foreach (var entityType in entityTypes)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(entityType.Name, entityType.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(entityType.Name, entityType.Namespace, OdcmClassKind.Entity);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    odcmClass.IsAbstract = entityType.IsAbstract;
+
+                    if (entityType.HasStream)
+                    {
+                        odcmClass.Kind = OdcmClassKind.MediaEntity;
+                    }
+
+                    if (entityType.BaseType != null)
+                    {
+                        var baseEntityType = (IEdmEntityType) entityType.BaseType;
+
+                        OdcmClass baseClass;
+                        if (!_odcmModel.TryResolveType(baseEntityType.Name, baseEntityType.Namespace, out baseClass))
+                        {
+                            baseClass = new OdcmClass(baseEntityType.Name, baseEntityType.Namespace,
+                                OdcmClassKind.Entity);
+                            _odcmModel.AddType(baseClass);
+                        }
+
+                        odcmClass.Base = baseClass;
+
+                        if (!baseClass.Derived.Contains(odcmClass))
+                            baseClass.Derived.Add(odcmClass);
+                    }
+
+                    var structuralProperties = from element in entityType.DeclaredProperties
+                        where element.PropertyKind == EdmPropertyKind.Structural
+                        select element as IEdmStructuralProperty;
+                    foreach (var structuralProperty in structuralProperties)
+                    {
+                        OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
+                        WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
+                    }
+
+                    foreach (IEdmStructuralProperty keyProperty in entityType.Key())
+                    {
+                        var property = FindProperty(odcmClass, keyProperty);
+                        if (property != null)
+                        {
+                            // The properties that compose the key MUST be non-nullable.
+                            property.IsNullable = false;
+                        }
+
+                        odcmClass.Key.Add(FindField(odcmClass, keyProperty));
+                    }
+
+                    var navigationProperties = from element in entityType.DeclaredProperties
+                        where element.PropertyKind == EdmPropertyKind.Navigation
+                        select element as IEdmNavigationProperty;
+                    foreach (var navigationProperty in navigationProperties)
+                    {
+                        OdcmField odcmField = WriteNavigationField(odcmClass, navigationProperty);
+                        WriteNavigationProperty(odcmClass, odcmField, navigationProperty);
+                    }
+
+                    var entityTypeActions = from element in actions
+                        where IsOperationBound(element, entityType)
+                        select element;
+                    foreach (var action in entityTypeActions)
+                    {
+                        WriteMethod(odcmClass, action);
+                    }
+
+                    var entityTypeFunctions = from element in functions
+                        where IsOperationBound(element, entityType)
+                        select element;
+                    foreach (var function in entityTypeFunctions)
+                    {
+                        WriteMethod(odcmClass, function);
+                    }
+                }
+
+                foreach (var entityContainer in entityContainers)
+                {
+                    OdcmClass odcmClass;
+                    if (!_odcmModel.TryResolveType(entityContainer.Name, entityContainer.Namespace, out odcmClass))
+                    {
+                        odcmClass = new OdcmClass(entityContainer.Name, entityContainer.Namespace, OdcmClassKind.Service);
+                        _odcmModel.AddType(odcmClass);
+                    }
+
+                    var entitySets = from element in entityContainer.Elements
+                        where element.ContainerElementKind == EdmContainerElementKind.EntitySet
+                        select element as IEdmEntitySet;
+                    foreach (var entitySet in entitySets)
+                    {
+                        OdcmField odcmField = WriteField(odcmClass, entitySet);
+                        WriteProperty(odcmClass, odcmField, entitySet);
+                    }
+
+                    var singletons = from element in entityContainer.Elements
+                        where element.ContainerElementKind == EdmContainerElementKind.Singleton
+                        select element as IEdmSingleton;
+                    foreach (var singleton in singletons)
+                    {
+                        OdcmField odcmField = WriteField(odcmClass, singleton);
+                        WriteProperty(odcmClass, odcmField, singleton);
+                    }
+
+                    var actionImports = from element in entityContainer.Elements
+                        where element.ContainerElementKind == EdmContainerElementKind.ActionImport
+                        select element as IEdmActionImport;
+                    foreach (var actionImport in actionImports)
+                    {
+                        WriteMethod(odcmClass, actionImport.Action);
+                    }
+
+                    var functionImports = from element in entityContainer.Elements
+                        where element.ContainerElementKind == EdmContainerElementKind.FunctionImport
+                        select element as IEdmFunctionImport;
+                    foreach (var functionImport in functionImports)
+                    {
+                        WriteMethod(odcmClass, functionImport.Function);
+                    }
+                }
+            }
+
+            private bool IsOperationBound(IEdmOperation operation, IEdmEntityType entityType)
+            {
+                var bindingParameterType = operation.Parameters.First().Type;
+                return string.Equals(bindingParameterType.FullName(), entityType.FullTypeName()) ||
+                       (bindingParameterType.IsCollection() &&
+                        string.Equals(bindingParameterType.AsCollection().ElementType().FullName(),
+                            entityType.FullTypeName()));
+            }
+
+            private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmEntitySet entitySet)
+            {
+                OdcmProperty odcmProperty = new OdcmProperty(entitySet.Name);
+                odcmProperty.Class = odcmClass;
+                odcmProperty.Field = odcmField;
+                odcmProperty.Type = odcmField.Type;
+                odcmClass.Properties.Add(odcmProperty);
+            }
+
+            private OdcmField WriteField(OdcmClass odcmClass, IEdmEntitySet entitySet)
+            {
+                OdcmField odcmField = new OdcmField("_" + entitySet.Name);
+                odcmField.Class = odcmClass;
+                odcmClass.Fields.Add(odcmField);
+
+                odcmField.Type = ResolveType(entitySet.EntityType().Name, entitySet.EntityType().Namespace,
+                    TypeKind.Entity);
+
+                odcmField.IsCollection = true;
+                odcmField.IsLink = true;
+
+                return odcmField;
+            }
+
+            private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmSingleton singleton)
+            {
+                OdcmProperty odcmProperty = new OdcmProperty(singleton.Name);
+                odcmProperty.Class = odcmClass;
+                odcmProperty.Type = odcmField.Type;
+                odcmClass.Properties.Add(odcmProperty);
+
+                odcmProperty.Field = odcmField;
+                odcmProperty.Type = odcmField.Type;
+            }
+
+            private OdcmField WriteField(OdcmClass odcmClass, IEdmSingleton singleton)
+            {
+                OdcmField odcmField = new OdcmField("_" + singleton.Name);
+                odcmField.Class = odcmClass;
+                odcmClass.Fields.Add(odcmField);
+
+                odcmField.Type = ResolveType(singleton.EntityType().Name, singleton.EntityType().Namespace,
+                    TypeKind.Entity);
+
+                odcmField.IsLink = true;
+
+                return odcmField;
+            }
+
+            private OdcmField FindField(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
+            {
+                foreach (OdcmField field in odcmClass.Fields)
+                {
+                    if (field.Name.Equals("_" + keyProperty.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return field;
+                    }
+                }
+
+                return null;
+            }
+
+            private OdcmProperty FindProperty(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
+            {
+                foreach (OdcmProperty property in odcmClass.Properties)
+                {
+                    if (property.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return property;
+                    }
+                }
+
+                return null;
+            }
+
+            private void WriteMethod(OdcmClass odcmClass, IEdmOperation operation)
+            {
+                IEnumerable<IEdmOperationParameter> parameters = operation.IsBound
+                    ? (from parameter in operation.Parameters
+                        where parameter != operation.Parameters.First()
+                        select parameter)
+                    : (operation.Parameters);
+
+                bool isBoundToCollection = operation.IsBound && operation.Parameters.First().Type.IsCollection();
+
+                var odcmMethod = new OdcmMethod(operation.Name)
+                {
+                    IsComposable = operation.IsFunction() && ((IEdmFunction) operation).IsComposable,
+                    IsBoundToCollection = isBoundToCollection,
+                    Verbs = operation.IsAction() ? OdcmAllowedVerbs.Post : OdcmAllowedVerbs.Any,
+                    Class = odcmClass
+                };
+
+                odcmClass.Methods.Add(odcmMethod);
+
+                if (operation.ReturnType != null)
+                {
+                    odcmMethod.ReturnType = ResolveType(operation.ReturnType);
+                    odcmMethod.IsCollection = operation.ReturnType.IsCollection();
+                }
+
+                var callingConvention =
+                    operation.IsAction()
+                        ? OdcmCallingConvention.InHttpMessageBody
+                        : OdcmCallingConvention.InHttpRequestUri;
+
+                foreach (var parameter in parameters)
+                {
+                    odcmMethod.Parameters.Add(new OdcmParameter(parameter.Name)
+                    {
+                        CallingConvention = callingConvention,
+                        Type = ResolveType(parameter.Type),
+                        IsCollection = parameter.Type.IsCollection(),
+                        IsNullable = parameter.Type.IsNullable
                     });
                 }
             }
 
-            foreach (var complexType in complexTypes)
+            private void WriteNavigationProperty(OdcmClass odcmClass, OdcmField odcmField,
+                IEdmNavigationProperty navigationProperty)
             {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(complexType.Name, complexType.Namespace, out odcmClass))
+                WriteProperty(odcmClass, odcmField, navigationProperty);
+            }
+
+            private void WriteStructuralProperty(OdcmClass odcmClass, OdcmField odcmField,
+                IEdmStructuralProperty structuralProperty)
+            {
+                WriteProperty(odcmClass, odcmField, structuralProperty);
+            }
+
+            private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmProperty property)
+            {
+                OdcmProperty odcmProperty = new OdcmProperty(property.Name);
+                odcmProperty.Class = odcmClass;
+                odcmProperty.IsNullable = property.Type.IsNullable;
+                odcmClass.Properties.Add(odcmProperty);
+
+                odcmProperty.Field = odcmField;
+
+                odcmProperty.Type = odcmField.Type;
+            }
+
+            private OdcmField WriteNavigationField(OdcmClass odcmClass, IEdmNavigationProperty navigationProperty)
+            {
+                OdcmField odcmField = WriteField(odcmClass, navigationProperty);
+
+                odcmField.ContainsTarget = navigationProperty.ContainsTarget;
+                odcmField.IsLink = true;
+
+                return odcmField;
+            }
+
+            private OdcmField WriteStructuralField(OdcmClass odcmClass, IEdmStructuralProperty structuralProperty)
+            {
+                return WriteField(odcmClass, structuralProperty);
+            }
+
+            private OdcmField WriteField(OdcmClass odcmClass, IEdmProperty property)
+            {
+                OdcmField odcmField = new OdcmField("_" + property.Name);
+                odcmField.Class = odcmClass;
+                odcmClass.Fields.Add(odcmField);
+
+                odcmField.Type = ResolveType(property.Type);
+                odcmField.IsCollection = property.Type.IsCollection();
+
+                return odcmField;
+            }
+
+            private OdcmType ResolveType(IEdmTypeReference realizedType)
+            {
+                if (realizedType.IsCollection())
                 {
-                    odcmClass = new OdcmClass(complexType.Name, complexType.Namespace, OdcmClassKind.Complex);
-                    OdcmModel.AddType(odcmClass);
+                    realizedType = realizedType.AsCollection().ElementType();
                 }
 
-                odcmClass.IsAbstract = complexType.IsAbstract;
+                if (realizedType.IsComplex())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Complex);
 
-                if (complexType.BaseType != null)
+                if (realizedType.IsEntity())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Entity);
+
+                if (realizedType.IsEnum())
+                    return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Enum);
+
+                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Primitive);
+            }
+
+            private OdcmType ResolveType(IEdmSchemaElement realizedSchemaElement, TypeKind kind)
+            {
+                return ResolveType(realizedSchemaElement.Name, realizedSchemaElement.Namespace, kind);
+            }
+
+            private OdcmType ResolveType(string name, string @namespace, TypeKind kind)
+            {
+                OdcmType type;
+
+                if (!_odcmModel.TryResolveType(name, @namespace, out type))
                 {
-                    OdcmClass baseClass;
-                    if (!OdcmModel.TryResolveType(((IEdmSchemaElement)complexType.BaseType).Name, ((IEdmSchemaElement)complexType.BaseType).Namespace, out baseClass))
+                    switch (kind)
                     {
-                        baseClass = new OdcmClass(((IEdmSchemaElement)complexType.BaseType).Name, ((IEdmSchemaElement)complexType.BaseType).Namespace, OdcmClassKind.Complex);
-                        OdcmModel.AddType(baseClass);
-                    }
-                    odcmClass.Base = baseClass;
-                    if(!baseClass.Derived.Contains(odcmClass))
-                        baseClass.Derived.Add(odcmClass);
-                }
-
-                var structuralProperties = from element in complexType.Properties()
-                                           where element.PropertyKind == EdmPropertyKind.Structural &&
-                                           element.DeclaringType == (IEdmStructuredType)complexType
-                                           select element as IEdmStructuralProperty;
-                foreach (var structuralProperty in structuralProperties)
-                {
-                    OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
-                    WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
-                }
-            }
-
-            foreach (var entityType in entityTypes)
-            {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(entityType.Name, entityType.Namespace, out odcmClass))
-                {
-                    odcmClass = new OdcmClass(entityType.Name, entityType.Namespace, OdcmClassKind.Entity);
-                    OdcmModel.AddType(odcmClass);
-                }
-
-                odcmClass.IsAbstract = entityType.IsAbstract;
-
-                if (entityType.BaseType != null)
-                {
-                    OdcmClass baseClass;
-                    if (!OdcmModel.TryResolveType(((IEdmSchemaElement)entityType.BaseType).Name, ((IEdmSchemaElement)entityType.BaseType).Namespace, out baseClass))
-                    {
-                        baseClass = new OdcmClass(((IEdmSchemaElement)entityType.BaseType).Name, ((IEdmSchemaElement)entityType.BaseType).Namespace, OdcmClassKind.Entity);
-                        OdcmModel.AddType(baseClass);
-                    }
-                    odcmClass.Base = baseClass;
-                    if(!baseClass.Derived.Contains(odcmClass))
-                        baseClass.Derived.Add(odcmClass);
-                }
-
-                var structuralProperties = from element in entityType.DeclaredProperties
-                                           where element.PropertyKind == EdmPropertyKind.Structural
-                                           select element as IEdmStructuralProperty;
-                foreach (var structuralProperty in structuralProperties)
-                {
-                    OdcmField odcmField = WriteStructuralField(odcmClass, structuralProperty);
-                    WriteStructuralProperty(odcmClass, odcmField, structuralProperty);
-                }
-
-                foreach (IEdmStructuralProperty keyProperty in entityType.Key())
-                {
-                    var property = FindProperty(odcmClass, keyProperty);
-                    if (property != null)
-                    {
-                        // The properties that compose the key MUST be non-nullable.
-                        property.IsNullable = false;
+                        case TypeKind.Complex:
+                            type = new OdcmClass(name, @namespace, OdcmClassKind.Complex);
+                            break;
+                        case TypeKind.Entity:
+                            type = new OdcmClass(name, @namespace, OdcmClassKind.Entity);
+                            break;
+                        case TypeKind.Enum:
+                            type = new OdcmEnum(name, @namespace);
+                            break;
+                        case TypeKind.Primitive:
+                            type = new OdcmPrimitiveType(name, @namespace);
+                            break;
                     }
 
-                    odcmClass.Key.Add(FindField(odcmClass, keyProperty));
+                    _odcmModel.AddType(type);
                 }
 
-                var navigationProperties = from element in entityType.DeclaredProperties
-                                           where element.PropertyKind == EdmPropertyKind.Navigation
-                                           select element as IEdmNavigationProperty;
-                foreach (var navigationProperty in navigationProperties)
-                {
-                    OdcmField odcmField = WriteNavigationField(odcmClass, navigationProperty);
-                    WriteNavigationProperty(odcmClass, odcmField, navigationProperty);
-                }
-
-                var entityTypeActions = from element in actions
-                                        where IsOperationBound(element, entityType)
-                                        select element;
-                foreach (var action in entityTypeActions)
-                {
-                    WriteMethod(odcmClass, action);
-                }
-
-                var entityTypeFunctions = from element in functions
-                                          where IsOperationBound(element, entityType)
-                                          select element;
-                foreach (var function in entityTypeFunctions)
-                {
-                    WriteMethod(odcmClass, function);
-                }
+                return type;
             }
-
-            foreach (var entityContainer in entityContainers)
-            {
-                OdcmClass odcmClass;
-                if (!OdcmModel.TryResolveType(entityContainer.Name, entityContainer.Namespace, out odcmClass))
-                {
-                    odcmClass = new OdcmClass(entityContainer.Name, entityContainer.Namespace, OdcmClassKind.Service);
-                    OdcmModel.AddType(odcmClass);
-                }
-
-                var entitySets = from element in entityContainer.Elements
-                                 where element.ContainerElementKind == EdmContainerElementKind.EntitySet
-                                 select element as IEdmEntitySet;
-                foreach (var entitySet in entitySets)
-                {
-                    OdcmField odcmField = WriteField(odcmClass, entitySet);
-                    WriteProperty(odcmClass, odcmField, entitySet);
-                }
-
-                var singletons = from element in entityContainer.Elements
-                                 where element.ContainerElementKind == EdmContainerElementKind.Singleton
-                                 select element as IEdmSingleton;
-                foreach (var singleton in singletons)
-                {
-                    OdcmField odcmField = WriteField(odcmClass, singleton);
-                    WriteProperty(odcmClass, odcmField, singleton);
-                }
-
-                var actionImports = from element in entityContainer.Elements
-                                    where element.ContainerElementKind == EdmContainerElementKind.ActionImport
-                                    select element as IEdmActionImport;
-                foreach (var actionImport in actionImports)
-                {
-                    WriteMethod(odcmClass, actionImport.Action);
-                }
-
-                var functionImports = from element in entityContainer.Elements
-                                      where element.ContainerElementKind == EdmContainerElementKind.FunctionImport
-                                      select element as IEdmFunctionImport;
-                foreach (var functionImport in functionImports)
-                {
-                    WriteMethod(odcmClass, functionImport.Function);
-                }
-            }
-        }
-
-        private bool IsOperationBound(IEdmOperation operation, IEdmEntityType entityType)
-        {
-            var bindingParameterType = operation.Parameters.First().Type;
-            return string.Equals(bindingParameterType.FullName(), entityType.FullTypeName()) ||
-                (bindingParameterType.IsCollection() && string.Equals(bindingParameterType.AsCollection().ElementType().FullName(), entityType.FullTypeName()));
-        }
-
-        private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmEntitySet entitySet)
-        {
-            OdcmProperty odcmProperty = new OdcmProperty(entitySet.Name);
-            odcmProperty.Class = odcmClass;
-            odcmProperty.Field = odcmField;
-            odcmProperty.Type = odcmField.Type;
-            odcmClass.Properties.Add(odcmProperty);
-        }
-
-        private OdcmField WriteField(OdcmClass odcmClass, IEdmEntitySet entitySet)
-        {
-            OdcmField odcmField = new OdcmField("_" + entitySet.Name);
-            odcmField.Class = odcmClass;
-            odcmClass.Fields.Add(odcmField);
-
-            odcmField.Type = ResolveType(entitySet.EntityType().Name, entitySet.EntityType().Namespace, TypeKind.Entity);
-
-            odcmField.IsCollection = true;
-            odcmField.IsLink = true;
-
-            return odcmField;
-        }
-
-        private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmSingleton singleton)
-        {
-            OdcmProperty odcmProperty = new OdcmProperty(singleton.Name);
-            odcmProperty.Class = odcmClass;
-            odcmProperty.Type = odcmField.Type;
-            odcmClass.Properties.Add(odcmProperty);
-
-            odcmProperty.Field = odcmField;
-            odcmProperty.Type = odcmField.Type;
-        }
-
-        private OdcmField WriteField(OdcmClass odcmClass, IEdmSingleton singleton)
-        {
-            OdcmField odcmField = new OdcmField("_" + singleton.Name);
-            odcmField.Class = odcmClass;
-            odcmClass.Fields.Add(odcmField);
-
-            odcmField.Type = ResolveType(singleton.EntityType().Name, singleton.EntityType().Namespace, TypeKind.Entity);
-
-            odcmField.IsLink = true;
-
-            return odcmField;
-        }
-
-        private OdcmField FindField(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
-        {
-            foreach (OdcmField field in odcmClass.Fields)
-            {
-                if (field.Name.Equals("_" + keyProperty.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return field;
-                }
-            }
-
-            return null;
-        }
-
-        private OdcmProperty FindProperty(OdcmClass odcmClass, IEdmStructuralProperty keyProperty)
-        {
-            foreach (OdcmProperty property in odcmClass.Properties)
-            {
-                if (property.Name.Equals(keyProperty.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return property;
-                }
-            }
-
-            return null;
-        }
-
-        private void WriteMethod(OdcmClass odcmClass, IEdmOperation operation)
-        {
-            IEnumerable<IEdmOperationParameter> parameters = operation.IsBound
-                ? (from parameter in operation.Parameters where parameter != operation.Parameters.First() select parameter)
-                : (operation.Parameters);
-
-            bool isBoundToCollection = operation.IsBound && operation.Parameters.First().Type.IsCollection();
-            
-            var odcmMethod = new OdcmMethod(operation.Name)
-            {
-                IsComposable = operation.IsFunction() && ((IEdmFunction)operation).IsComposable,
-                IsBoundToCollection = isBoundToCollection,
-                Verbs = operation.IsAction() ? OdcmAllowedVerbs.Post : OdcmAllowedVerbs.Any,
-                Class = odcmClass
-            };
-
-            odcmClass.Methods.Add(odcmMethod);
-
-            if (operation.ReturnType != null)
-            {
-                odcmMethod.ReturnType = ResolveType(operation.ReturnType);
-                odcmMethod.IsCollection = operation.ReturnType.IsCollection();
-            }
-
-            var callingConvention =
-                operation.IsAction()
-                    ? OdcmCallingConvention.InHttpMessageBody
-                    : OdcmCallingConvention.InHttpRequestUri;
-
-            foreach (var parameter in parameters)
-            {
-                odcmMethod.Parameters.Add(new OdcmParameter(parameter.Name)
-                {
-                    CallingConvention = callingConvention,
-                    Type = ResolveType(parameter.Type),
-                    IsCollection = parameter.Type.IsCollection(),
-                    IsNullable = parameter.Type.IsNullable
-                });
-            }
-        }
-
-        private void WriteNavigationProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmNavigationProperty navigationProperty)
-        {
-            WriteProperty(odcmClass, odcmField, navigationProperty);
-        }
-
-        private void WriteStructuralProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmStructuralProperty structuralProperty)
-        {
-            WriteProperty(odcmClass, odcmField, structuralProperty);
-        }
-
-        private void WriteProperty(OdcmClass odcmClass, OdcmField odcmField, IEdmProperty property)
-        {
-            OdcmProperty odcmProperty = new OdcmProperty(property.Name);
-            odcmProperty.Class = odcmClass;
-            odcmProperty.IsNullable = property.Type.IsNullable;
-            odcmClass.Properties.Add(odcmProperty);
-
-            odcmProperty.Field = odcmField;
-
-            odcmProperty.Type = odcmField.Type;
-        }
-
-        private OdcmField WriteNavigationField(OdcmClass odcmClass, IEdmNavigationProperty navigationProperty)
-        {
-            OdcmField odcmField = WriteField(odcmClass, navigationProperty);
-
-            odcmField.ContainsTarget = navigationProperty.ContainsTarget;
-            odcmField.IsLink = true;
-
-            return odcmField;
-        }
-
-        private OdcmField WriteStructuralField(OdcmClass odcmClass, IEdmStructuralProperty structuralProperty)
-        {
-            return WriteField(odcmClass, structuralProperty);
-        }
-
-        private OdcmField WriteField(OdcmClass odcmClass, IEdmProperty property)
-        {
-            OdcmField odcmField = new OdcmField("_" + property.Name);
-            odcmField.Class = odcmClass;
-            odcmClass.Fields.Add(odcmField);
-
-            odcmField.Type = ResolveType(property.Type);
-            odcmField.IsCollection = property.Type.IsCollection();
-
-            return odcmField;
-        }
-
-        private OdcmType ResolveType(IEdmTypeReference realizedType)
-        {
-            if (realizedType.IsCollection())
-            {
-                realizedType = realizedType.AsCollection().ElementType();
-            }
-
-            if (realizedType.IsComplex())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Complex);
-
-            if (realizedType.IsEntity())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Entity);
-
-            if (realizedType.IsEnum())
-                return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Enum);
-
-            return ResolveType(realizedType.Definition as IEdmSchemaElement, TypeKind.Primitive);
-        }
-
-        private OdcmType ResolveType(IEdmSchemaElement realizedSchemaElement, TypeKind kind)
-        {
-            return ResolveType(realizedSchemaElement.Name, realizedSchemaElement.Namespace, kind);
-        }
-
-        private OdcmType ResolveType(string name, string @namespace, TypeKind kind)
-        {
-            OdcmType type;
-
-            if (!OdcmModel.TryResolveType(name, @namespace, out type))
-            {
-                switch (kind)
-                {
-                    case TypeKind.Complex:
-                        type = new OdcmClass(name, @namespace, OdcmClassKind.Complex);
-                        break;
-                    case TypeKind.Entity:
-                        type = new OdcmClass(name, @namespace, OdcmClassKind.Entity);
-                        break;
-                    case TypeKind.Enum:
-                        type = new OdcmEnum(name, @namespace);
-                        break;
-                    case TypeKind.Primitive:
-                        type = new OdcmPrimitiveType(name, @namespace);
-                        break;
-                }
-
-                OdcmModel.AddType(type);
-            }
-
-            return type;
         }
     }
 }

--- a/src/Readers/ODataReader.v4/Reader.cs
+++ b/src/Readers/ODataReader.v4/Reader.cs
@@ -133,6 +133,7 @@ namespace ODataReader.v4
                     }
 
                     odcmClass.IsAbstract = complexType.IsAbstract;
+                    odcmClass.IsOpen = complexType.IsOpen;
 
                     if (complexType.BaseType != null)
                     {
@@ -171,6 +172,7 @@ namespace ODataReader.v4
                     }
 
                     odcmClass.IsAbstract = entityType.IsAbstract;
+                    odcmClass.IsOpen = entityType.IsOpen;
 
                     if (entityType.HasStream)
                     {

--- a/src/Writers/CSharpWriter/CSharpWriter.Code.cs
+++ b/src/Writers/CSharpWriter/CSharpWriter.Code.cs
@@ -25,8 +25,6 @@ namespace CSharpWriter
 
             ConfigurationService.Initialize(configurationProvider);
 
-            TypeService.Initialize(Model);
-
             if (model.ServiceType == ServiceType.ODataV4)
             {
                 _dependencies.Add("global::Microsoft.OData.Client");

--- a/src/Writers/CSharpWriter/CSharpWriter.Code.cs
+++ b/src/Writers/CSharpWriter/CSharpWriter.Code.cs
@@ -134,6 +134,7 @@ namespace CSharpWriter
                     Write(Class.ForComplex(odcmClass));
                     break;
 
+                case OdcmClassKind.MediaEntity:
                 case OdcmClassKind.Entity:
                     Write(Interface.ForConcrete(odcmClass));
 

--- a/src/Writers/CSharpWriter/Methods.cs
+++ b/src/Writers/CSharpWriter/Methods.cs
@@ -112,11 +112,11 @@ namespace CSharpWriter
             return GetMethodsBoundToEntityType(odcmClass);
         }
 
-        private static IEnumerable<Method> ForFetcherUpcasts(OdcmType odcmClass)
+        private static IEnumerable<Method> ForFetcherUpcasts(OdcmClass odcmClass)
         {
             return ConfigurationService.OmitFetcherUpcastMethods
                 ? Methods.Emtpy
-                : TypeService.DerivedTypes[odcmClass]
+                : odcmClass.NestedDerivedTypes()
                     .Select(dr => new FetcherUpcastMethod(odcmClass, dr));
         }
 
@@ -127,11 +127,11 @@ namespace CSharpWriter
                     .Select(p => new ContainerAddToCollectionMethod(p));
         }
 
-        private static IEnumerable<Method> ForConcreteUpcasts(OdcmType odcmClass)
+        private static IEnumerable<Method> ForConcreteUpcasts(OdcmClass odcmClass)
         {
             return ConfigurationService.OmitFetcherUpcastMethods
                 ? Methods.Emtpy
-                : TypeService.DerivedTypes[odcmClass]
+                : odcmClass.NestedDerivedTypes()
                     .Select(dr => new ConcreteUpcastMethod(odcmClass, dr));
         }
 

--- a/src/Writers/CSharpWriter/NamesService.cs
+++ b/src/Writers/CSharpWriter/NamesService.cs
@@ -37,6 +37,11 @@ namespace CSharpWriter
                 return GetConcreteInterfaceName(odcmType);
             }
 
+            if (odcmType is OdcmClass && ((OdcmClass)odcmType).Kind == OdcmClassKind.MediaEntity)
+            {
+                return GetConcreteInterfaceName(odcmType);
+            }
+
             var resolvedName = ResolveIdentifier(odcmType);
 
             return new Identifier(resolvedName.Namespace, resolvedName.Name + (isCollection ? "[]" : string.Empty));

--- a/src/Writers/CSharpWriter/TypeService.cs
+++ b/src/Writers/CSharpWriter/TypeService.cs
@@ -11,16 +11,6 @@ namespace CSharpWriter
 {
     public static class TypeService
     {
-        public static ImmutableDictionary<OdcmType, IEnumerable<OdcmType>> DerivedTypes { get; private set; }
-
-        public static void Initialize(OdcmModel model)
-        {
-            var allTypes = model.Namespaces.SelectMany(n => n.Types).ToList();
-
-            DerivedTypes =
-                allTypes.ToImmutableDictionary(t => t, bt => allTypes.Where(dt => dt.Base == bt));
-        }
-
         public static bool IsValueType(OdcmType type)
         {
             if (type == null)

--- a/test/CSharpWriterUnitTests/Any.cs
+++ b/test/CSharpWriterUnitTests/Any.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CSharpWriter;
 using Vipr.Core.CodeModel;
 
 namespace Microsoft.Its.Recipes
@@ -59,6 +60,11 @@ namespace Microsoft.Its.Recipes
             }
 
             classes[0].Base = classes[1];
+
+            if (!classes[1].Derived.Contains(classes[0]))
+            {
+                classes[1].Derived.Add(classes[0]);
+            }
 
             retVal.Types.AddRange(classes);
 

--- a/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
@@ -34,6 +34,10 @@ namespace CSharpWriterUnitTests
                 _baseClass = Any.EntityOdcmClass(@namespace);
                 @namespace.Types.Add(_baseClass);
                 derivedClass.Base = _baseClass;
+                if (!_baseClass.Derived.Contains(derivedClass))
+                {
+                    _baseClass.Derived.Add(derivedClass);
+                }
             });
 
             _baseConcreteType = Proxy.GetClass(_baseClass.Namespace, _baseClass.Name);

--- a/test/ODataReader.v4UnitTests/Any.cs
+++ b/test/ODataReader.v4UnitTests/Any.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Messaging;
 using System.Xml.Linq;
 
 namespace Microsoft.Its.Recipes
@@ -18,248 +20,311 @@ namespace Microsoft.Its.Recipes
             return camelCaseName.Substring(0, 1).ToLowerInvariant() + camelCaseName.Substring(1);
         }
 
-        public static XElement Action(Action<XElement> config = null)
+
+        internal static class Csdl
         {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string actionString = string.Format(ODataReader.v4UnitTests.Properties.Resources.Action_element,
-                pascalCaseName);
+            private readonly static string[] PrimitiveTypes = new[]
+            {
+                "Edm.Binary",
+                "Edm.Boolean",
+                "Edm.Byte",
+                "Edm.Date",
+                "Edm.DateTimeOffset",
+                "Edm.Decimal",
+                "Edm.Double",
+                "Edm.Duration",
+                "Edm.Guid",
+                "Edm.Int16",
+                "Edm.Int32",
+                "Edm.Int64",
+                "Edm.SByte",
+                "Edm.Single",
+                "Edm.Stream",
+                "Edm.String",
+                "Edm.TimeOfDay",
+                "Edm.Geography",
+                "Edm.GeographyPoint",
+                "Edm.GeographyLineString",
+                "Edm.GeographyPolygon",
+                "Edm.GeographyMultiPoint",
+                "Edm.GeographyMultiLineString",
+                "Edm.GeographyMultiPolygon",
+                "Edm.GeographyCollection",
+                "Edm.Geometry",
+                "Edm.GeometryPoint",
+                "Edm.GeometryLineString",
+                "Edm.GeometryPolygon",
+                "Edm.GeometryMultiPoint",
+                "Edm.GeometryMultiLineString",
+                "Edm.GeometryMultiPolygon",
+                "Edm.GeometryCollection"
+            };
+
+            public static string RandomPrimitiveType()
+            {
+                return PrimitiveTypes.RandomElement();
+            }
+            public static string DefaultEnumUnderlyingType()
+            {
+                return PrimitiveTypes[10];
+            }
+
+            public static string RandomEnumUnderlyingType()
+            {
+                int[] primitiveTypeIndices = {2, 9, 10, 11, 12};
+                return PrimitiveTypes[primitiveTypeIndices.RandomElement()];
+            }
+
+            public static XElement Action(Action<XElement> config = null)
+            {
+                var pascalCaseName = PascalCaseName(Int(1, 3));
+                var actionString = string.Format(ODataReader.v4UnitTests.Properties.Resources.Action_element, pascalCaseName);
+
+                var element = XElement.Parse(actionString);
+
+                if (config != null) config(element);
+
+                return element;
+            }
+
+            public static XElement ActionImport(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string actionImportString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.ActionImport_element, pascalCaseName);
+
+                XElement element = XElement.Parse(actionImportString);
+
+                if (config != null) config(element);
+
+                return element;
+            }
+
+            public static XElement ComplexType(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string complexTypeString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.ComplexType_element, pascalCaseName);
+
+                XElement element = XElement.Parse(complexTypeString);
+
+                if (config != null) config(element);
+
+                return element;
+            }
+
+            public static XElement DataServices(Action<XElement> config = null)
+            {
+                var element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.DataServices_element);
+
+                if (config != null) config(element);
+
+                return element;
+            }
+
+            public static XElement Edmx(Action<XElement> config = null)
+            {
+                XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.Edmx_element);
 
-            XElement element = XElement.Parse(actionString);
+                if (config != null) config(element);
 
-            if (config != null) config(element);
+                return element;
+            }
 
-            return element;
-        }
+            public static XElement EntityContainer(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string entityContainerString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.EntityContainer_element, pascalCaseName);
 
-        public static XElement ActionImport(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string actionImportString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.ActionImport_element, pascalCaseName);
+                XElement element = XElement.Parse(entityContainerString);
 
-            XElement element = XElement.Parse(actionImportString);
+                if (config != null) config(element);
 
-            if (config != null) config(element);
+                return element;
+            }
 
-            return element;
-        }
+            public static XElement EntitySet(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string entitySetString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.EntitySet_element, pascalCaseName);
 
-        public static XElement ComplexType(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string complexTypeString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.ComplexType_element, pascalCaseName);
+                XElement element = XElement.Parse(entitySetString);
 
-            XElement element = XElement.Parse(complexTypeString);
+                if (config != null) config(element);
 
-            if (config != null) config(element);
+                return element;
+            }
 
-            return element;
-        }
+            public static XElement EntityType(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string entityTypeString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.EntityType_element, pascalCaseName);
 
-        public static XElement DataServices(Action<XElement> config = null)
-        {
-            XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.DataServices_element);
+                XElement element = XElement.Parse(entityTypeString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement Edmx(Action<XElement> config = null)
-        {
-            XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.Edmx_element);
+            public static XElement EnumType(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string enumTypeString = string.Format(ODataReader.v4UnitTests.Properties.Resources.EnumType_element,
+                    pascalCaseName);
 
-            if (config != null) config(element);
+                XElement element = XElement.Parse(enumTypeString);
 
-            return element;
-        }
+                if (config != null) config(element);
 
-        public static XElement EntityContainer(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1,3));
-            string entityContainerString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.EntityContainer_element, pascalCaseName);
+                return element;
+            }
 
-            XElement element = XElement.Parse(entityContainerString);
+            public static XElement Function(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string functionString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.Function_element, pascalCaseName);
 
-            if (config != null) config(element);
+                XElement element = XElement.Parse(functionString);
 
-            return element;
-        }
+                if (config != null) config(element);
 
-        public static XElement EntitySet(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string entitySetString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.EntitySet_element, pascalCaseName);
+                return element;
+            }
 
-            XElement element = XElement.Parse(entitySetString);
+            public static XElement FunctionImport(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string functionImportString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.FunctionImport_element, pascalCaseName);
 
-            if (config != null) config(element);
+                XElement element = XElement.Parse(functionImportString);
 
-            return element;
-        }
+                if (config != null) config(element);
 
-        public static XElement EntityType(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string entityTypeString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.EntityType_element, pascalCaseName);
+                return element;
+            }
 
-            XElement element = XElement.Parse(entityTypeString);
+            public static XElement Key(Action<XElement> config = null)
+            {
+                XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.Key_element);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement EnumType(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string enumTypeString = string.Format(ODataReader.v4UnitTests.Properties.Resources.EnumType_element,
-                pascalCaseName);
+            public static XElement Member(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string memberString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.Member_element, pascalCaseName);
 
-            XElement element = XElement.Parse(enumTypeString);
+                XElement element = XElement.Parse(memberString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement Function(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string functionString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.Function_element, pascalCaseName);
+            public static XElement NavigationProperty(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string navigationPropertyString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.NavigationProperty_element,
+                        pascalCaseName);
 
-            XElement element = XElement.Parse(functionString);
+                XElement element = XElement.Parse(navigationPropertyString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement FunctionImport(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string functionImportString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.FunctionImport_element, pascalCaseName);
+            public static XElement Parameter(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string parameterString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.Parameter_element, pascalCaseName);
 
-            XElement element = XElement.Parse(functionImportString);
+                XElement element = XElement.Parse(parameterString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement Key(Action<XElement> config = null)
-        {
-            XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.Key_element);
+            public static XElement Property(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string propertyString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.Property_element, pascalCaseName);
 
-            if (config != null) config(element);
+                XElement element = XElement.Parse(propertyString);
 
-            return element;
-        }
+                if (config != null) config(element);
 
-        public static XElement Member(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string memberString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.Member_element, pascalCaseName);
+                return element;
+            }
 
-            XElement element = XElement.Parse(memberString);
+            public static XElement PropertyRef(Action<XElement> config = null)
+            {
+                XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.PropertyRef_element);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement NavigationProperty(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string navigationPropertyString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.NavigationProperty_element, pascalCaseName);
+            public static XElement ReturnType(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string returnTypeString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.ReturnType_element, pascalCaseName);
 
-            XElement element = XElement.Parse(navigationPropertyString);
+                XElement element = XElement.Parse(returnTypeString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement Parameter(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string parameterString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.Parameter_element, pascalCaseName);
+            public static XElement Schema(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string schemaString = string.Format(ODataReader.v4UnitTests.Properties.Resources.Schema_element,
+                    pascalCaseName);
 
-            XElement element = XElement.Parse(parameterString);
+                XElement element = XElement.Parse(schemaString);
 
-            if (config != null) config(element);
+                if (config != null) config(element);
 
-            return element;
-        }
+                return element;
+            }
 
-        public static XElement Property(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string propertyString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.Property_element, pascalCaseName);
+            public static XElement EdmxToSchema(Action<XElement> config = null)
+            {
+                return Edmx(edmx => 
+                    edmx.Add(DataServices(dataServices => 
+                        dataServices.Add(Schema(config)))));
+            }
 
-            XElement element = XElement.Parse(propertyString);
+            public static XElement Singleton(Action<XElement> config = null)
+            {
+                string pascalCaseName = PascalCaseName(Int(1, 3));
+                string singletonString =
+                    string.Format(ODataReader.v4UnitTests.Properties.Resources.Singleton_element, pascalCaseName);
 
-            if (config != null) config(element);
+                XElement element = XElement.Parse(singletonString);
 
-            return element;
-        }
+                if (config != null) config(element);
 
-        public static XElement PropertyRef(Action<XElement> config = null)
-        {
-            XElement element = XElement.Parse(ODataReader.v4UnitTests.Properties.Resources.PropertyRef_element);
-
-            if (config != null) config(element);
-
-            return element;
-        }
-
-        public static XElement ReturnType(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string returnTypeString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.ReturnType_element, pascalCaseName);
-
-            XElement element = XElement.Parse(returnTypeString);
-
-            if (config != null) config(element);
-
-            return element;
-        }
-
-        public static XElement Schema(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string schemaString = string.Format(ODataReader.v4UnitTests.Properties.Resources.Schema_element,
-                pascalCaseName);
-
-            XElement element = XElement.Parse(schemaString);
-
-            if (config != null) config(element);
-
-            return element;
-        }
-
-        public static XElement Singleton(Action<XElement> config = null)
-        {
-            string pascalCaseName = PascalCaseName(Int(1, 3));
-            string singletonString =
-                string.Format(ODataReader.v4UnitTests.Properties.Resources.Singleton_element, pascalCaseName);
-
-            XElement element = XElement.Parse(singletonString);
-
-            if (config != null) config(element);
-
-            return element;
+                return element;
+            }
         }
     }
 }

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_complex_types_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_complex_types_when_passed_to_the_ODataReader.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.Its.Recipes;
+using ODataReader.v4;
+using System.Collections.Generic;
+using Vipr.Core.CodeModel;
+using Xunit;
+
+namespace ODataReader.v4UnitTests
+{
+    public class Given_a_valid_edmx_with_complex_types_when_passed_to_the_ODataReader
+    {
+        private ODataReader.v4.Reader reader;
+
+        public Given_a_valid_edmx_with_complex_types_when_passed_to_the_ODataReader()
+        {
+            reader = new Reader();
+        }
+
+        [Fact]
+        public void It_returns_one_OdcmClass_for_each_ComplexType()
+        {
+            var complexTypeName = string.Empty;
+            var schemaNamespace = string.Empty;
+            var propertyCount = 0;
+
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.ComplexType(complexType =>
+                {
+                    foreach (
+                        var property in
+                            Any.Sequence(
+                                i =>
+                                    Any.Csdl.Property(
+                                        property => property.AddAttribute("Type", Any.Csdl.RandomPrimitiveType())),
+                                Any.Int(1, 5)))
+                    {
+                        complexType.Add(property);
+                        propertyCount++;
+                    }
+
+                    complexTypeName = complexType.Attribute("Name").Value;
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
+
+            var serviceMetadata = new Dictionary<string, string>()
+            {
+                {"$metadata", edmxElement.ToString()}
+            };
+            var odcmModel = reader.GenerateOdcmModel(serviceMetadata);
+
+            OdcmType odcmComplexType;
+            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+                .Should()
+                .BeTrue("because a complex type in the schema should result in an OdcmType");
+            odcmComplexType
+                .Should()
+                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmClass>().Properties.Count
+                .Should()
+                .Be(propertyCount, "because each blah...");
+        }
+
+        [Fact]
+        public void When_IsAbstract_is_set_it_returns_an_OdcmClass_with_IsAbstract_set()
+        {
+            var complexTypeName = string.Empty;
+            var schemaNamespace = string.Empty;
+
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.ComplexType(complexType =>
+                {
+                    complexTypeName = complexType.Attribute("Name").Value;
+                    complexType.AddAttribute("Abstract", true);
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
+
+            var serviceMetadata = new Dictionary<string, string>()
+            {
+                {"$metadata", edmxElement.ToString()}
+            };
+            var odcmModel = reader.GenerateOdcmModel(serviceMetadata);
+
+            OdcmType odcmComplexType;
+            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+                .Should()
+                .BeTrue("because a complex type in the schema should result in an OdcmType");
+            odcmComplexType
+                .Should()
+                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmClass>().IsAbstract
+                .Should()
+                .BeTrue("because a complex type with the IsAbstract facet set should be abstact");
+        }
+    }
+}

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_enum_types_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_enum_types_when_passed_to_the_ODataReader.cs
@@ -4,8 +4,8 @@
 using FluentAssertions;
 using Microsoft.Its.Recipes;
 using ODataReader.v4;
+using System;
 using System.Collections.Generic;
-using System.Xml.Linq;
 using Vipr.Core.CodeModel;
 using Xunit;
 
@@ -27,23 +27,20 @@ namespace ODataReader.v4UnitTests
             var enumName = string.Empty;
             var enumMemberCount = 0;
 
-            var edmxElement =
-                Any.Edmx(edmx => edmx.Add(
-                    Any.DataServices(dataServices => dataServices.Add(
-                        Any.Schema(schema =>
-                        {
-                            schema.Add(Any.EnumType(enumType =>
-                            {
-                                foreach (var member in Any.Sequence((i) => Any.Member(), Any.Int(1, 5)))
-                                {
-                                    enumType.Add(member);
-                                    enumMemberCount++;
-                                }
-                                enumName = enumType.Attribute("Name").Value;
-                            }));
-                            schema.Add(Any.EntityContainer());
-                            schemaNamespace = schema.Attribute("Namespace").Value;
-                        })))));
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.EnumType(enumType =>
+                {
+                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                    {
+                        enumType.Add(member);
+                        enumMemberCount++;
+                    }
+                    enumName = enumType.Attribute("Name").Value;
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
 
             var serviceMetadata = new Dictionary<string, string>()
             {
@@ -59,6 +56,137 @@ namespace ODataReader.v4UnitTests
             odcmEnum.As<OdcmEnum>()
                 .Members.Count.Should()
                 .Be(enumMemberCount, "because each member added to the schema should result in an OdcmMember");
+        }
+
+        [Fact]
+        public void When_IsFlags_is_set_it_returns_an_OdcmEnum_with_IsFlags_set()
+        {
+            var schemaNamespace = string.Empty;
+            var enumName = string.Empty;
+            var enumMemberCount = 0;
+
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.EnumType(enumType =>
+                {
+                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                    {
+                        member.AddAttribute("Value", (int)Math.Pow(enumMemberCount, 2));
+                        enumType.Add(member);
+                        enumMemberCount++;
+                    }
+                    enumName = enumType.Attribute("Name").Value;
+                    enumType.AddAttribute("IsFlags", true);
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
+
+            var serviceMetadata = new Dictionary<string, string>()
+            {
+                {"$metadata", edmxElement.ToString()}
+            };
+            var odcmModel = reader.GenerateOdcmModel(serviceMetadata);
+
+            OdcmType odcmEnum;
+            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+                .Should()
+                .BeTrue("because an enum type in the schema should result in an OdcmType");
+            odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
+            odcmEnum.As<OdcmEnum>()
+                .Members.Count.Should()
+                .Be(enumMemberCount, "because each member added to the schema should result in an OdcmMember");
+            odcmEnum.As<OdcmEnum>()
+                .IsFlags.Should()
+                .BeTrue(
+                    "because an enum type in the schema with the IsFlags facet set to true should result in an OdcmEnum with the IsFlags property set to true");
+        }
+
+        [Fact]
+        public void When_No_Underlying_Type_is_set_it_returns_an_OdcmEnum_with_a_Default_UnderlyingType()
+        {
+            var schemaNamespace = string.Empty;
+            var enumName = string.Empty;
+            var enumMemberCount = 0;
+
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.EnumType(enumType =>
+                {
+                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                    {
+                        enumType.Add(member);
+                        enumMemberCount++;
+                    }
+                    enumName = enumType.Attribute("Name").Value;
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
+
+            var serviceMetadata = new Dictionary<string, string>()
+            {
+                {"$metadata", edmxElement.ToString()}
+            };
+            var odcmModel = reader.GenerateOdcmModel(serviceMetadata);
+
+            OdcmType odcmEnum;
+            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+                .Should()
+                .BeTrue("because an enum type in the schema should result in an OdcmType");
+            odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
+            odcmEnum.As<OdcmEnum>().Members.Count
+                .Should()
+                .Be(enumMemberCount, "because each member added to the schema should result in an OdcmMember");
+            odcmEnum.As<OdcmEnum>().UnderlyingType.FullName
+                .Should()
+                .Be(Any.Csdl.DefaultEnumUnderlyingType(),
+                    "because an enum type without an explicit underlying type in the schema should have the default underlying type in an OdcmEnum");
+        }
+
+        [Fact]
+        public void When_An_Underlying_Type_is_set_it_returns_an_OdcmEnum_with_the_specified_UnderlyingType()
+        {
+            var schemaNamespace = string.Empty;
+            var enumName = string.Empty;
+            var enumMemberCount = 0;
+            var underlyingType = string.Empty;
+
+            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
+            {
+                schema.Add(Any.Csdl.EnumType(enumType =>
+                {
+                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                    {
+                        enumType.Add(member);
+                        enumMemberCount++;
+                    }
+                    enumName = enumType.Attribute("Name").Value;
+                    underlyingType = Any.Csdl.RandomEnumUnderlyingType();
+                    enumType.AddAttribute("UnderlyingType", underlyingType);
+                }));
+                schema.Add(Any.Csdl.EntityContainer());
+                schemaNamespace = schema.Attribute("Namespace").Value;
+            });
+
+            var serviceMetadata = new Dictionary<string, string>()
+            {
+                {"$metadata", edmxElement.ToString()}
+            };
+            var odcmModel = reader.GenerateOdcmModel(serviceMetadata);
+
+            OdcmType odcmEnum;
+            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+                .Should()
+                .BeTrue("because an enum type in the schema should result in an OdcmType");
+            odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
+            odcmEnum.As<OdcmEnum>().Members.Count
+                .Should()
+                .Be(enumMemberCount, "because each member added to the schema should result in an OdcmMember");
+            odcmEnum.As<OdcmEnum>().UnderlyingType.FullName
+                .Should()
+                .Be(underlyingType,
+                    "because an enum type with an explicit underlying type in the schema should have the specified underlying type in an OdcmEnum");
         }
     }
 }

--- a/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
+++ b/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
@@ -72,6 +72,7 @@
       <Link>%28Its.Recipes%29\TestInputGenerator.cs</Link>
     </Compile>
     <Compile Include="Any.cs" />
+    <Compile Include="Given_a_valid_edmx_with_complex_types_when_passed_to_the_ODataReader.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -80,6 +81,7 @@
     <Compile Include="Given_a_valid_edmx_element_when_passed_to_the_ODataReader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Given_a_valid_edmx_with_enum_types_when_passed_to_the_ODataReader.cs" />
+    <Compile Include="XElementExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Vipr.Core\Vipr.Core.csproj">

--- a/test/ODataReader.v4UnitTests/XElementExtensions.cs
+++ b/test/ODataReader.v4UnitTests/XElementExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace ODataReader.v4UnitTests
+{
+    public static class XElementExtensions
+    {
+        public static void AddAttribute(this XElement element, string name, object value)
+        {
+            element.Add(new XAttribute(name, value));
+        }
+    }
+}


### PR DESCRIPTION
Refinements to the OdcmModel:

[1] Since only classes inherit, Base and Derived properties moved from OdcmType to OdcmClass.
[2] Added IsAbstract and IsFlags to OdcmClass and OdcmEnum, respectively.
[3] Removed OdcmModel property from IReader and enabled multi-threaded execution of ODataReader.v3 and ODataReader.v4.
[4] Added a few new unit tests to ODataReader.v4UnitTests.