### PR TITLE
Using Odcm model concept of derived types for emitting upcast methods.

### DIFF
--- a/src/Writers/CSharpWriter/Methods.cs
+++ b/src/Writers/CSharpWriter/Methods.cs
@@ -116,7 +116,7 @@ namespace CSharpWriter
         {
             return ConfigurationService.OmitFetcherUpcastMethods
                 ? Methods.Emtpy
-                : TypeService.DerivedTypes[odcmClass]
+                : odcmClass.Derived
                     .Select(dr => new FetcherUpcastMethod(odcmClass, dr));
         }
 
@@ -131,7 +131,7 @@ namespace CSharpWriter
         {
             return ConfigurationService.OmitFetcherUpcastMethods
                 ? Methods.Emtpy
-                : TypeService.DerivedTypes[odcmClass]
+                : odcmClass.Derived
                     .Select(dr => new ConcreteUpcastMethod(odcmClass, dr));
         }
 

--- a/src/Writers/CSharpWriter/TypeService.cs
+++ b/src/Writers/CSharpWriter/TypeService.cs
@@ -11,14 +11,9 @@ namespace CSharpWriter
 {
     public static class TypeService
     {
-        public static ImmutableDictionary<OdcmType, IEnumerable<OdcmType>> DerivedTypes { get; private set; }
-
         public static void Initialize(OdcmModel model)
         {
             var allTypes = model.Namespaces.SelectMany(n => n.Types).ToList();
-
-            DerivedTypes =
-                allTypes.ToImmutableDictionary(t => t, bt => allTypes.Where(dt => dt.Base == bt));
         }
 
         public static bool IsValueType(OdcmType type)

--- a/test/CSharpWriterUnitTests/Any.cs
+++ b/test/CSharpWriterUnitTests/Any.cs
@@ -60,6 +60,9 @@ namespace Microsoft.Its.Recipes
 
             classes[0].Base = classes[1];
 
+            if (!classes[1].Derived.Contains(classes[0]))
+                classes[1].Derived.Add(classes[0]);
+
             retVal.Types.AddRange(classes);
 
             if (config != null) config(retVal);

--- a/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
@@ -34,6 +34,8 @@ namespace CSharpWriterUnitTests
                 _baseClass = Any.EntityOdcmClass(@namespace);
                 @namespace.Types.Add(_baseClass);
                 derivedClass.Base = _baseClass;
+                if (!_baseClass.Derived.Contains(derivedClass))
+                    _baseClass.Derived.Add(derivedClass);
             });
 
             _baseConcreteType = Proxy.GetClass(_baseClass.Namespace, _baseClass.Name);


### PR DESCRIPTION
- Earlier CSharpwriter was maintaining a cache of Derived types for a given OdcmType. This was getting used to emit the upcast methods.
- Removed the above cache and instead started using the OdcmType.Derived list property.