### PR TITLE
Add Media Entity support to code generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ UpgradeLog*.htm
 FakesAssemblies/
 *.v2.ncrunchproject
 *.v2.ncrunchsolution
+/Vipr.sln.GhostDoc.xml

--- a/src/Core/Vipr.Core/CodeModel/OdcmAnnotatedObject.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmAnnotatedObject.cs
@@ -9,7 +9,7 @@ namespace Vipr.Core.CodeModel
 
         public string InText { get; set; }
 
-        public OdcmAnnotatedObject(string name)
+        protected OdcmAnnotatedObject(string name)
             : base(name)
         {
         }

--- a/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmClass.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Vipr.Core.CodeModel
 {
-    public class OdcmClass : OdcmType
+    public abstract class OdcmClass : OdcmType
     {
         public bool IsAbstract { get; set; }
 
@@ -21,10 +21,10 @@ namespace Vipr.Core.CodeModel
 
         public List<OdcmMethod> Methods { get; private set; }
 
-        public OdcmClass(string name, OdcmNamespace @namespace)
+        public OdcmClass(string name, OdcmNamespace @namespace, OdcmClassKind kind)
             : base(name, @namespace)
         {
-            Kind = OdcmClassKind.Complex;
+            Kind = kind;
             Properties = new List<OdcmProperty>();
             Methods = new List<OdcmMethod>();
             Derived = new List<OdcmClass>();

--- a/src/Core/Vipr.Core/CodeModel/OdcmComplexClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmComplexClass.cs
@@ -5,7 +5,7 @@ namespace Vipr.Core.CodeModel
 {
     public class OdcmComplexClass : OdcmClass
     {
-        public OdcmComplexClass(string name, string @namespace) :
+        public OdcmComplexClass(string name, OdcmNamespace @namespace) :
             base(name, @namespace, OdcmClassKind.Complex)
         {
         }

--- a/src/Core/Vipr.Core/CodeModel/OdcmComplexClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmComplexClass.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Vipr.Core.CodeModel
+{
+    public class OdcmComplexClass : OdcmClass
+    {
+        public OdcmComplexClass(string name, string @namespace) :
+            base(name, @namespace, OdcmClassKind.Complex)
+        {
+        }
+    }
+}

--- a/src/Core/Vipr.Core/CodeModel/OdcmEntityClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmEntityClass.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Vipr.Core.CodeModel
 {
@@ -11,9 +10,13 @@ namespace Vipr.Core.CodeModel
         public List<OdcmProperty> Key { get; private set; }
 
         public OdcmEntityClass(string name, OdcmNamespace @namespace) :
-            base(name, @namespace)
+            this(name, @namespace, OdcmClassKind.Entity)
         {
-            Kind = OdcmClassKind.Entity;
+        }
+
+        protected OdcmEntityClass(string name, OdcmNamespace @namespace, OdcmClassKind kind) :
+            base(name, @namespace, kind)
+        {
             Key = new List<OdcmProperty>();
         }
     }

--- a/src/Core/Vipr.Core/CodeModel/OdcmMediaClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmMediaClass.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Vipr.Core.CodeModel
 {
     public class OdcmMediaClass : OdcmEntityClass
     {
         public OdcmMediaClass(string name, OdcmNamespace @namespace)
-            : base(name, @namespace)
+            : base(name, @namespace, OdcmClassKind.MediaEntity)
         {
-            Kind = OdcmClassKind.MediaEntity;
         }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
@@ -33,7 +33,5 @@ namespace Vipr.Core.CodeModel
         {
             return MakeCanonicalName(Name, ReturnType, Parameters.ToArray());
         }
-
-        public string FullName { get { return Namespace.Name + "." + Name; } }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Vipr.Core.CodeModel
 {

--- a/src/Core/Vipr.Core/CodeModel/OdcmNamespace.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmNamespace.cs
@@ -31,8 +31,13 @@ namespace Vipr.Core.CodeModel
         {
             get
             {
-                return from odcmType in Types where odcmType is OdcmClass select odcmType as OdcmClass;
+                return ClassesOf<OdcmClass>();
             }
+        }
+
+        public IEnumerable<T> ClassesOf<T>() where T : OdcmClass
+        {
+            return from odcmType in Types where odcmType is T select odcmType as T;
         }
 
         public static OdcmNamespace Edm { get { return EdmNamespace; } }

--- a/src/Core/Vipr.Core/CodeModel/OdcmNamespace.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmNamespace.cs
@@ -31,13 +31,8 @@ namespace Vipr.Core.CodeModel
         {
             get
             {
-                return ClassesOf<OdcmClass>();
+                return from odcmType in Types where odcmType is OdcmClass select odcmType as OdcmClass;
             }
-        }
-
-        public IEnumerable<T> ClassesOf<T>() where T : OdcmClass
-        {
-            return from odcmType in Types where odcmType is T select odcmType as T;
         }
 
         public static OdcmNamespace Edm { get { return EdmNamespace; } }

--- a/src/Core/Vipr.Core/CodeModel/OdcmObject.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmObject.cs
@@ -9,7 +9,7 @@ namespace Vipr.Core.CodeModel
     {
         public string Name { get; private set; }
 
-        public OdcmObject(string name)
+        protected OdcmObject(string name)
         {
             Name = name;
         }

--- a/src/Core/Vipr.Core/CodeModel/OdcmServiceClass.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmServiceClass.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Vipr.Core.CodeModel
 {
     public class OdcmServiceClass : OdcmClass
     {
         public OdcmServiceClass(string name, OdcmNamespace @namespace)
-            : base(name, @namespace)
+            : base(name, @namespace, OdcmClassKind.Service)
         {
-            Kind = OdcmClassKind.Service;
         }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmType.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmType.cs
@@ -9,7 +9,7 @@ namespace Vipr.Core.CodeModel
 
         public OdcmNamespace Namespace { get; set; }
 
-        public OdcmType(string name, OdcmNamespace @namespace)
+        protected OdcmType(string name, OdcmNamespace @namespace)
             : base(name)
         {
             Namespace = @namespace;

--- a/src/Core/Vipr.Core/CodeModel/OdcmType.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmType.cs
@@ -5,8 +5,6 @@ namespace Vipr.Core.CodeModel
 {
     public abstract class OdcmType : OdcmAnnotatedObject
     {
-        public readonly static string Global = "global";
-
         public OdcmNamespace Namespace { get; set; }
 
         protected OdcmType(string name, OdcmNamespace @namespace)

--- a/src/Core/Vipr.Core/Vipr.Core.csproj
+++ b/src/Core/Vipr.Core/Vipr.Core.csproj
@@ -44,6 +44,7 @@
     <Compile Include="CodeModel\OdcmCallingConvention.cs" />
     <Compile Include="CodeModel\OdcmClassKind.cs" />
     <Compile Include="CodeModel\OdcmAllowedVerbs.cs" />
+    <Compile Include="CodeModel\OdcmComplexClass.cs" />
     <Compile Include="CodeModel\OdcmEntityClass.cs" />
     <Compile Include="CodeModel\OdcmMediaClass.cs" />
     <Compile Include="CodeModel\OdcmServiceClass.cs" />

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/BatchElementResult.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/BatchElementResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Microsoft.OData.ProxyExtensions

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/ComplexTypeBase.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/ComplexTypeBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Microsoft.OData.ProxyExtensions

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/EntityCollectionImpl.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/EntityCollectionImpl.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using Microsoft.OData.Client;
 
@@ -69,8 +72,4 @@ namespace Microsoft.OData.ProxyExtensions
             }
         }
     }
-}
-
-namespace Microsoft.OData.ProxyExtensions
-{
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IBatchElementResult.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IBatchElementResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Microsoft.OData.ProxyExtensions

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IConcreteTypeAccessor.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IConcreteTypeAccessor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace Microsoft.OData.ProxyExtensions

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IEntityBase.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IEntityBase.cs
@@ -1,10 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.OData.Client;
+
 namespace Microsoft.OData.ProxyExtensions
 {
     public interface IEntityBase
     {
-        /// <param name=""dontSave"">true to delay saving until batch is saved; false to save immediately.</param>
-        global::System.Threading.Tasks.Task UpdateAsync(bool dontSave = false);
-        /// <param name=""dontSave"">true to delay saving until batch is saved; false to save immediately.</param>
-        global::System.Threading.Tasks.Task DeleteAsync(bool dontSave = false);
+        /// <param name="deferSaveChanges">true to delay saving until batch is saved; false to save immediately.</param>
+        Task UpdateAsync(bool deferSaveChanges = false);
+        /// <param name="deferSaveChanges">true to delay saving until batch is saved; false to save immediately.</param>
+        Task DeleteAsync(bool deferSaveChanges = false);
+
+        /// <param name="deferSaveChanges">true to delay saving until batch is saved; false to save immediately.</param>
+        /// <param name="saveChangesOption">Save changes option to control how change requests are sent to the service.</param>
+        Task SaveChangesAsync(bool deferSaveChanges = false, SaveChangesOptions saveChangesOption = SaveChangesOptions.None);
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IMediaEntityBase.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IMediaEntityBase.cs
@@ -6,16 +6,14 @@ using System.Threading.Tasks;
 
 namespace Microsoft.OData.ProxyExtensions
 {
-    public interface IStreamFetcher
+    public interface IMediaEntityBase : IEntityBase
     {
-        string ContentType { get; }
-
-        Task<Client.DataServiceStreamResponse> DownloadAsync();
-
         /// <param name="stream">The stream content to upload.</param>
         /// <param name="contentType">The content type of the stream content.</param>
         /// <param name="deferSaveChanges">true to delay saving until batch is saved; false to save immediately.</param>
         /// <param name="closeStream">true to close stream after the upload is complete; false to leave stream open.</param>
-        Task UploadAsync(Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false);
+        Task UploadMediaAsync(Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false);
+
+        Task<Client.DataServiceStreamResponse> DownloadMediaAsync();
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IPagedCollection.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IPagedCollection.cs
@@ -1,16 +1,26 @@
-﻿namespace Microsoft.OData.ProxyExtensions
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.ProxyExtensions
 {
     public interface IPagedCollection
     {
-        global::System.Collections.Generic.IReadOnlyList<object> CurrentPage { get; }
+        IReadOnlyList<object> CurrentPage { get; }
+
         bool MorePagesAvailable { get; }
-        global::System.Threading.Tasks.Task<IPagedCollection> GetNextPageAsync();
+
+        Task<IPagedCollection> GetNextPageAsync();
     }
 
     public interface IPagedCollection<TElement>
     {
-        global::System.Collections.Generic.IReadOnlyList<TElement> CurrentPage { get; }
+        IReadOnlyList<TElement> CurrentPage { get; }
+
         bool MorePagesAvailable { get; }
-        global::System.Threading.Tasks.Task<IPagedCollection<TElement>> GetNextPageAsync();
+
+        Task<IPagedCollection<TElement>> GetNextPageAsync();
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IReadOnlyQueryableSet.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IReadOnlyQueryableSet.cs
@@ -1,8 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
 namespace Microsoft.OData.ProxyExtensions
 {
     public interface IReadOnlyQueryableSet<TSource> : IReadOnlyQueryableSetBase<TSource>
     {
-        System.Threading.Tasks.Task<IPagedCollection<TSource>> ExecuteAsync();
-        System.Threading.Tasks.Task<TSource> ExecuteSingleAsync();
+        Task<IPagedCollection<TSource>> ExecuteAsync();
+
+        Task<TSource> ExecuteSingleAsync();
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IReadOnlyQueryableSetBase.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/IReadOnlyQueryableSetBase.cs
@@ -1,23 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
+using System.Linq.Expressions;
 using Microsoft.OData.Client;
 
 namespace Microsoft.OData.ProxyExtensions
 {
     public interface IReadOnlyQueryableSetBase<TSource> : IReadOnlyQueryableSetBase
     {
-        IReadOnlyQueryableSet<TSource> Expand<TTarget>(System.Linq.Expressions.Expression<Func<TSource, TTarget>> navigationPropertyAccessor);
+        IReadOnlyQueryableSet<TSource> Expand(string expansion);
+
+        IReadOnlyQueryableSet<TSource> Expand<TTarget>(Expression<Func<TSource, TTarget>> navigationPropertyAccessor);
+
         IReadOnlyQueryableSet<TResult> OfType<TResult>();
-        IReadOnlyQueryableSet<TSource> OrderBy<TKey>(System.Linq.Expressions.Expression<Func<TSource, TKey>> keySelector);
-        IReadOnlyQueryableSet<TSource> OrderByDescending<TKey>(System.Linq.Expressions.Expression<Func<TSource, TKey>> keySelector);
-        IReadOnlyQueryableSet<TResult> Select<TResult>(System.Linq.Expressions.Expression<Func<TSource, TResult>> selector);
+
+        IReadOnlyQueryableSet<TSource> OrderBy<TKey>(Expression<Func<TSource, TKey>> keySelector);
+
+        IReadOnlyQueryableSet<TSource> OrderByDescending<TKey>(Expression<Func<TSource, TKey>> keySelector);
+
+        IReadOnlyQueryableSet<TResult> Select<TResult>(Expression<Func<TSource, TResult>> selector);
+
         IReadOnlyQueryableSet<TSource> Skip(int count);
+
         IReadOnlyQueryableSet<TSource> Take(int count);
-        IReadOnlyQueryableSet<TSource> Where(System.Linq.Expressions.Expression<Func<TSource, bool>> predicate);
+
+        IReadOnlyQueryableSet<TSource> Where(Expression<Func<TSource, bool>> predicate);
     }
 
     public interface IReadOnlyQueryableSetBase
     {
         DataServiceContextWrapper Context { get; }
+
         DataServiceQuery Query { get; }
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/LowerCasePropertyAttribute.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/LowerCasePropertyAttribute.cs
@@ -1,6 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
 namespace Microsoft.OData.ProxyExtensions
 {
-    public class LowerCasePropertyAttribute : System.Attribute
+    public class LowerCasePropertyAttribute : Attribute
     {
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/MediaEntityBase.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/MediaEntityBase.cs
@@ -6,16 +6,27 @@ using System.Threading.Tasks;
 
 namespace Microsoft.OData.ProxyExtensions
 {
-    public interface IStreamFetcher
+    public class MediaEntityBase : EntityBase, IMediaEntityBase
     {
-        string ContentType { get; }
-
-        Task<Client.DataServiceStreamResponse> DownloadAsync();
-
         /// <param name="stream">The stream content to upload.</param>
         /// <param name="contentType">The content type of the stream content.</param>
         /// <param name="deferSaveChanges">true to delay saving until batch is saved; false to save immediately.</param>
         /// <param name="closeStream">true to close stream after the upload is complete; false to leave stream open.</param>
-        Task UploadAsync(Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false);
+        public Task UploadMediaAsync(Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false)
+        {
+            var args = new Client.DataServiceRequestArgs
+            {
+                ContentType = contentType
+            };
+
+            Context.SetSaveStream(this, stream, closeStream, args);
+
+            return SaveChangesAsync(deferSaveChanges);
+        }
+
+        public Task<Client.DataServiceStreamResponse> DownloadMediaAsync()
+        {
+            return Context.GetReadStreamAsync(this, null);
+        }
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/Microsoft.OData.ProxyExtensions.csproj
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/Microsoft.OData.ProxyExtensions.csproj
@@ -45,11 +45,13 @@
     <Compile Include="IBatchElementResult.cs" />
     <Compile Include="IConcreteTypeAccessor.cs" />
     <Compile Include="IEntityBase.cs" />
+    <Compile Include="IMediaEntityBase.cs" />
     <Compile Include="IPagedCollection.cs" />
     <Compile Include="IReadOnlyQueryableSet.cs" />
     <Compile Include="IReadOnlyQueryableSetBase.cs" />
     <Compile Include="IStreamFetcher.cs" />
     <Compile Include="LowerCasePropertyAttribute.cs" />
+    <Compile Include="MediaEntityBase.cs" />
     <Compile Include="NonEntityTypeCollectionImpl.cs" />
     <Compile Include="PagedCollection.cs" />
     <Compile Include="StreamFetcher.cs" />

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/NonEntityTypeCollectionImpl.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/NonEntityTypeCollectionImpl.cs
@@ -1,23 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
 
 namespace Microsoft.OData.ProxyExtensions
 {
-    public class NonEntityTypeCollectionImpl<T> : global::System.Collections.ObjectModel.Collection<T>
+    public class NonEntityTypeCollectionImpl<T> : Collection<T>
     {
         private Func<Tuple<EntityBase, string>> _entity;
 
-        private static readonly bool s_isComplexType = System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(T)).IsSubclassOf(typeof(ComplexTypeBase));
-
-        public NonEntityTypeCollectionImpl()
-            : base()
-        {
-        }
+        private static readonly bool GenericArgumentIsComplexType =
+            typeof (T).GetTypeInfo().IsSubclassOf(typeof (ComplexTypeBase));
 
         public void SetContainer(Func<Tuple<EntityBase, string>> entity)
         {
             _entity = entity;
 
-            if (s_isComplexType)
+            if (GenericArgumentIsComplexType)
             {
                 foreach (var i in this)
                 {
@@ -28,10 +29,9 @@ namespace Microsoft.OData.ProxyExtensions
 
         protected override void InsertItem(int index, T item)
         {
-            var ct = item as ComplexTypeBase;
-            if (ct != null)
+            if (GenericArgumentIsComplexType)
             {
-                ct.SetContainer(_entity);
+                (item as ComplexTypeBase).SetContainer(_entity);
             }
 
             base.InsertItem(index, item);
@@ -42,31 +42,34 @@ namespace Microsoft.OData.ProxyExtensions
         protected override void ClearItems()
         {
             base.ClearItems();
+
             InvokeOnPropertyChanged();
         }
 
         protected override void RemoveItem(int index)
         {
             base.RemoveItem(index);
+
             InvokeOnPropertyChanged();
         }
 
         protected override void SetItem(int index, T item)
         {
-            var ct = item as ComplexTypeBase;
-            if (ct != null)
+            if (GenericArgumentIsComplexType)
             {
-                ct.SetContainer(_entity);
+                (item as ComplexTypeBase).SetContainer(_entity);
             }
+
             base.SetItem(index, item);
+
             InvokeOnPropertyChanged();
         }
 
         private void InvokeOnPropertyChanged()
         {
-            var tuple = _entity != null ? _entity() : null;
-            if (tuple != null)
+            if (_entity != null)
             {
+                var tuple = _entity();
                 tuple.Item1.OnPropertyChanged(tuple.Item2);
             }
         }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/PagedCollection.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/PagedCollection.cs
@@ -1,14 +1,19 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.OData.Client;
 
 namespace Microsoft.OData.ProxyExtensions
 {
-    public class PagedCollection<TElement, TConcrete> : IPagedCollection, IPagedCollection<TElement> where TConcrete : TElement
+    public class PagedCollection<TElement, TConcrete> : IPagedCollection, IPagedCollection<TElement>
+        where TConcrete : TElement
     {
-        private DataServiceContextWrapper _context;
-        private DataServiceQueryContinuation<TConcrete> _continuation;
-        private IReadOnlyList<TElement> _currentPage;
+        private readonly DataServiceContextWrapper _context;
+        private readonly DataServiceQueryContinuation<TConcrete> _continuation;
+        private readonly IReadOnlyList<TElement> _currentPage;
 
         // Creator - should be faster than Activator.CreateInstance
         public static PagedCollection<TElement, TConcrete> Create(DataServiceContextWrapper context,
@@ -21,14 +26,14 @@ namespace Microsoft.OData.ProxyExtensions
             QueryOperationResponse<TConcrete> qor)
         {
             _context = context;
-            _currentPage = (IReadOnlyList<TElement>)qor.ToList();
+            _currentPage = (IReadOnlyList<TElement>) qor.ToList();
             _continuation = qor.GetContinuation();
         }
 
         public PagedCollection(DataServiceContextWrapper context, DataServiceCollection<TConcrete> collection)
         {
             _context = context;
-            _currentPage = (IReadOnlyList<TElement>)collection;
+            _currentPage = (IReadOnlyList<TElement>) collection;
             if (_currentPage != null)
             {
                 _continuation = collection.Continuation;
@@ -37,21 +42,15 @@ namespace Microsoft.OData.ProxyExtensions
 
         public bool MorePagesAvailable
         {
-            get
-            {
-                return _continuation != null;
-            }
+            get { return _continuation != null; }
         }
 
-        public System.Collections.Generic.IReadOnlyList<TElement> CurrentPage
+        public IReadOnlyList<TElement> CurrentPage
         {
-            get
-            {
-                return _currentPage;
-            }
+            get { return _currentPage; }
         }
 
-        public async System.Threading.Tasks.Task<IPagedCollection<TElement>> GetNextPageAsync()
+        public async Task<IPagedCollection<TElement>> GetNextPageAsync()
         {
             if (_continuation != null)
             {
@@ -60,19 +59,19 @@ namespace Microsoft.OData.ProxyExtensions
                 return new PagedCollection<TElement, TConcrete>(_context, await task);
             }
 
-            return (IPagedCollection<TElement>)null;
+            return null;
         }
 
         IReadOnlyList<object> IPagedCollection.CurrentPage
         {
-            get { return (IReadOnlyList<object>)this.CurrentPage; }
+            get { return (IReadOnlyList<object>) CurrentPage; }
         }
 
-        async System.Threading.Tasks.Task<IPagedCollection> IPagedCollection.GetNextPageAsync()
+        async Task<IPagedCollection> IPagedCollection.GetNextPageAsync()
         {
             var retval = await GetNextPageAsync();
 
-            return (PagedCollection<TElement, TConcrete>)retval;
+            return (PagedCollection<TElement, TConcrete>) retval;
         }
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/QueryableSet.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/QueryableSet.cs
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.OData.Client;
 
@@ -7,46 +9,40 @@ namespace Microsoft.OData.ProxyExtensions
 {
     public class QueryableSet<TSource> : ReadOnlyQueryableSetBase<TSource>
     {
-        protected string _path;
-        protected object _entity;
+        protected string Path;
+        protected object Entity;
 
         public void SetContainer(Func<EntityBase> entity, string property)
         {
             // Unneeded
         }
 
-        protected System.Uri GetUrl()
+        protected Uri GetUrl()
         {
-            return new Uri(Context.BaseUri.ToString().TrimEnd('/') + "/" + _path);
+            return new Uri(Context.BaseUri.ToString().TrimEnd('/') + "/" + Path);
         }
 
         protected string GetPath<TInstance>(Expression<Func<TInstance, bool>> whereExpression) where TInstance : TSource
         {
-            var query = (DataServiceQuery)System.Linq.Queryable.Where(Context.CreateQuery<TInstance>(_path), whereExpression);
+            var query =
+                (DataServiceQuery) System.Linq.Queryable.Where(Context.CreateQuery<TInstance>(Path), whereExpression);
 
             var path = query.RequestUri.ToString().Substring(Context.BaseUri.ToString().TrimEnd('/').Length + 1);
 
             return path;
         }
 
-        public QueryableSet(
-            DataServiceQuery inner,
-            DataServiceContextWrapper context,
-            EntityBase entity,
-            string path)
+        public QueryableSet(DataServiceQuery inner, DataServiceContextWrapper context, EntityBase entity, string path)
             : base(inner, context)
         {
             Initialize(inner, context, entity, path);
         }
 
-        public void Initialize(DataServiceQuery inner,
-            DataServiceContextWrapper context,
-            EntityBase entity,
-            string path)
+        public void Initialize(DataServiceQuery inner, DataServiceContextWrapper context, EntityBase entity, string path)
         {
-            base.Initialize(inner, context);
-            _path = path;
-            _entity = entity;
+            Initialize(inner, context);
+            Path = path;
+            Entity = entity;
         }
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/ReadOnlyQueryableSet.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/ReadOnlyQueryableSet.cs
@@ -1,25 +1,26 @@
-﻿using Microsoft.OData.Client;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.OData.Client;
 
 namespace Microsoft.OData.ProxyExtensions
 {
     public class ReadOnlyQueryableSet<TSource> : ReadOnlyQueryableSetBase<TSource>, IReadOnlyQueryableSet<TSource>
     {
-        public ReadOnlyQueryableSet(
-            DataServiceQuery inner,
-            DataServiceContextWrapper context)
+        public ReadOnlyQueryableSet(DataServiceQuery inner, DataServiceContextWrapper context)
             : base(inner, context)
         {
         }
-
-
-        public global::System.Threading.Tasks.Task<IPagedCollection<TSource>> ExecuteAsync()
+        
+        public Task<IPagedCollection<TSource>> ExecuteAsync()
         {
-            return base.ExecuteAsyncInternal();
+            return ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task<TSource> ExecuteSingleAsync()
+        public Task<TSource> ExecuteSingleAsync()
         {
-            return base.ExecuteSingleAsyncInternal();
+            return ExecuteSingleAsyncInternal();
         }
     }
 }

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/RestShallowObjectFetcher.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/RestShallowObjectFetcher.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using Microsoft.OData.Client;
 
@@ -6,26 +9,15 @@ namespace Microsoft.OData.ProxyExtensions
     public class RestShallowObjectFetcher : BaseEntityType
     {
         private string _path;
-
         private bool _isInitialized;
 
         public new DataServiceContextWrapper Context
         {
-            get
-            {
-                return (DataServiceContextWrapper)base.Context;
-            }
-            private set
-            {
-                base.Context = value;
-            }
+            get { return (DataServiceContextWrapper) base.Context; }
+            private set { base.Context = value; }
         }
 
-        public RestShallowObjectFetcher() { }
-
-        public void Initialize(
-            DataServiceContextWrapper context,
-            string path)
+        public void Initialize(DataServiceContextWrapper context, string path)
         {
             Context = context;
             _path = path;
@@ -36,10 +28,10 @@ namespace Microsoft.OData.ProxyExtensions
         {
             ThrowIfNotInitialized();
 
-            return propertyName == null ? this._path : this._path + "/" + propertyName;
+            return propertyName == null ? _path : _path + "/" + propertyName;
         }
 
-        protected System.Uri GetUrl()
+        protected Uri GetUrl()
         {
             ThrowIfNotInitialized();
 
@@ -51,7 +43,7 @@ namespace Microsoft.OData.ProxyExtensions
         {
             ThrowIfNotInitialized();
 
-            return new ReadOnlyQueryableSet<TIInstance>(this.Context.CreateQuery<TInstance>(this.GetPath(null)), this.Context);
+            return new ReadOnlyQueryableSet<TIInstance>(Context.CreateQuery<TInstance>(GetPath(null)), Context);
         }
 
         private void ThrowIfNotInitialized()

--- a/src/Readers/ODataReader.v3/OdcmReader.cs
+++ b/src/Readers/ODataReader.v3/OdcmReader.cs
@@ -18,7 +18,7 @@ namespace ODataReader.v3
 {
     public class OdcmReader : IOdcmReader
     {
-        private static readonly string[][] PrimitiveTypes = new[]
+        private static readonly string[][] PrimitiveTypes =
         {
             new[] {"Edm", "Binary"},
             new[] {"Edm", "Boolean"},
@@ -161,7 +161,7 @@ namespace ODataReader.v3
 
                 foreach (var complexType in complexTypes)
                 {
-                    _odcmModel.AddType(new OdcmClass(complexType.Name, ResolveNamespace(complexType.Namespace)));
+                    _odcmModel.AddType(new OdcmComplexClass(complexType.Name, ResolveNamespace(complexType.Namespace)));
                 }
 
                 foreach (var entityType in entityTypes)
@@ -171,8 +171,7 @@ namespace ODataReader.v3
 
                 foreach (var entityContainer in entityContainers)
                 {
-                    _odcmModel.AddType(new OdcmServiceClass(entityContainer.Name,
-                        ResolveNamespace(entityContainer.Namespace)));
+                    _odcmModel.AddType(new OdcmServiceClass(entityContainer.Name, ResolveNamespace(entityContainer.Namespace)));
                 }
             }
 

--- a/src/Readers/ODataReader.v4/OdcmReader.cs
+++ b/src/Readers/ODataReader.v4/OdcmReader.cs
@@ -156,7 +156,7 @@ namespace ODataReader.v4
 
                 foreach (var complexType in complexTypes)
                 {
-                    _odcmModel.AddType(new OdcmClass(complexType.Name, ResolveNamespace(complexType.Namespace)));
+                    _odcmModel.AddType(new OdcmComplexClass(complexType.Name, ResolveNamespace(complexType.Namespace)));
                 }
 
                 foreach (var entityType in entityTypes)
@@ -173,8 +173,7 @@ namespace ODataReader.v4
 
                 foreach (var entityContainer in entityContainers)
                 {
-                    _odcmModel.AddType(new OdcmServiceClass(entityContainer.Name,
-                        ResolveNamespace(entityContainer.Namespace)));
+                    _odcmModel.AddType(new OdcmServiceClass(entityContainer.Name, ResolveNamespace(entityContainer.Namespace)));
                 }
             }
 

--- a/src/Writers/CSharpWriter/AddAsyncMediaMethod.cs
+++ b/src/Writers/CSharpWriter/AddAsyncMediaMethod.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Vipr.Core.CodeModel;
+
+
+namespace CSharpWriter
+{
+    class AddAsyncMediaMethod : Method
+    {
+        public AddAsyncMediaMethod(OdcmClass odcmClass)
+        {
+            Name = "Add" + odcmClass.Name + "Async";
+
+            Parameters = new[]
+            {
+                new Parameter(new Type(NamesService.GetConcreteInterfaceName(odcmClass)), "item"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("IStream")), "stream"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("String")), "contentType"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "deferSaveChanges", "false"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "closeStream", "false")
+            };
+
+            ReturnType = new Type(Identifier.Task);
+
+            Visibility = ConfigurationService.Settings.MediaEntityAddAsyncVisibility;
+        }
+    }
+}

--- a/src/Writers/CSharpWriter/AddAsyncMethod.cs
+++ b/src/Writers/CSharpWriter/AddAsyncMethod.cs
@@ -14,7 +14,7 @@ namespace CSharpWriter
             Parameters = new[]
             {
                 new Parameter(new Type(NamesService.GetConcreteInterfaceName(odcmClass)), "item"),
-                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "dontSave", "false")
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "deferSaveChanges", "false")
             };
 
             ReturnType = new Type(Identifier.Task);

--- a/src/Writers/CSharpWriter/AutoProperty.cs
+++ b/src/Writers/CSharpWriter/AutoProperty.cs
@@ -5,9 +5,9 @@ namespace CSharpWriter
 {
     public class AutoProperty : Property
     {
-        public AutoProperty(string name, Type type, bool isPublic = true, bool privateGet = false, bool privateSet = false) : base(name)
+        public AutoProperty(string name, Type type, Visibility visibility = Visibility.Public, bool privateGet = false, bool privateSet = false) : base(name)
         {
-            IsPublic = isPublic;
+            Visibility = visibility;
             Name = name;
             PrivateGet = privateGet;
             PrivateSet = privateSet;

--- a/src/Writers/CSharpWriter/CSharpWriter.csproj
+++ b/src/Writers/CSharpWriter/CSharpWriter.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddAsyncMediaMethod.cs" />
     <Compile Include="Classes.cs" />
     <Compile Include="CollectionCountAsyncMethod.cs" />
     <Compile Include="ContainerAddToCollectionMethod.cs" />
@@ -133,6 +134,7 @@
     <Compile Include="Type.cs" />
     <Compile Include="TypeService.cs" />
     <Compile Include="UpcastMethodBase.cs" />
+    <Compile Include="Visibility.cs" />
     <Compile Include="WriterExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Writers/CSharpWriter/ContainerGetPathMethod.cs
+++ b/src/Writers/CSharpWriter/ContainerGetPathMethod.cs
@@ -7,8 +7,7 @@ namespace CSharpWriter
     {
         public ContainerGetPathMethod()
         {
-            IsPublic = false;
-
+            Visibility = Visibility.Private;
             Name = "GetPath";
             Parameters = new[] { new Parameter(new Type(new Identifier("System", "String")), "propertyName"), };
             ReturnType = new Type(new Identifier("System", "String"));

--- a/src/Writers/CSharpWriter/ContainerGetUrlMethod.cs
+++ b/src/Writers/CSharpWriter/ContainerGetUrlMethod.cs
@@ -7,8 +7,7 @@ namespace CSharpWriter
     {
         public ContainerGetUrlMethod()
         {
-            IsPublic = false;
-
+            Visibility = Visibility.Private;
             Name = "GetUrl";
             Parameters = new Parameter[] { };
             ReturnType = new Type(new Identifier("System", "Uri"));

--- a/src/Writers/CSharpWriter/ContainerNameFromTypeMethod.cs
+++ b/src/Writers/CSharpWriter/ContainerNameFromTypeMethod.cs
@@ -14,7 +14,7 @@ namespace CSharpWriter
         public ContainerNameFromTypeMethod(OdcmClass odcmContainer)
         {
             ClientNamespace = NamesService.GetNamespaceName(odcmContainer.Namespace);
-            IsPublic = false;
+            Visibility = Visibility.Private;
             Name = "ResolveNameFromType";
             Parameters = new[] { new Parameter(new Type(new Identifier("global::System", "Type")), "clientType"), };
             ReturnType = new Type(new Identifier("System", "String"));

--- a/src/Writers/CSharpWriter/ContainerTypeFromNameMethod.cs
+++ b/src/Writers/CSharpWriter/ContainerTypeFromNameMethod.cs
@@ -14,7 +14,7 @@ namespace CSharpWriter
         public ContainerTypeFromNameMethod(OdcmClass odcmContainer)
         {
             ClientNamespace = NamesService.GetNamespaceName(odcmContainer.Namespace);
-            IsPublic = false;
+            Visibility = Visibility.Private;
             Name = "ResolveTypeFromName";
             Parameters = new[] { new Parameter(new Type(new Identifier("System", "String")), "typeName"), };
             ReturnType = new Type(new Identifier("global::System", "Type"));

--- a/src/Writers/CSharpWriter/EnsureQueryMethod.cs
+++ b/src/Writers/CSharpWriter/EnsureQueryMethod.cs
@@ -12,7 +12,7 @@ namespace CSharpWriter
 
         public EnsureQueryMethod(OdcmClass odcmClass)
         {
-            IsPublic = false;
+            Visibility = Visibility.Private;
             Name = "EnsureQuery";
             FetchedType = new Type(NamesService.GetConcreteTypeName(odcmClass));
             FetchedTypeInterface = new Type(NamesService.GetConcreteInterfaceName(odcmClass));

--- a/src/Writers/CSharpWriter/Features.cs
+++ b/src/Writers/CSharpWriter/Features.cs
@@ -29,7 +29,7 @@ namespace CSharpWriter
             switch (odcmClass.Kind)
             {
                 case OdcmClassKind.Complex:
-                    return Features.ForOdcmClassComplex(odcmClass);
+                    return Features.ForOdcmClassComplex((OdcmComplexClass)odcmClass);
 
                 case OdcmClassKind.MediaEntity:
                 case OdcmClassKind.Entity:
@@ -52,7 +52,7 @@ namespace CSharpWriter
                     return Enumerable.Empty<Feature>();
 
                 case OdcmClassKind.Service:
-                    return Features.ForOdcmClassService(odcmClass, model);
+                    return Features.ForOdcmClassService((OdcmServiceClass)odcmClass, model);
             }
 
             throw new NotImplementedException(string.Format("OdcmClassKind {0} is not recognized", odcmClass.Kind));
@@ -80,7 +80,7 @@ namespace CSharpWriter
             return retVal;
         }
 
-        private static IEnumerable<Feature> ForOdcmClassComplex(OdcmClass odcmClass)
+        private static IEnumerable<Feature> ForOdcmClassComplex(OdcmComplexClass odcmClass)
         {
             return new[]
             {

--- a/src/Writers/CSharpWriter/FetcherExpandMethod.cs
+++ b/src/Writers/CSharpWriter/FetcherExpandMethod.cs
@@ -12,7 +12,7 @@ namespace CSharpWriter
 
         private FetcherExpandMethod(OdcmClass odcmClass)
         {
-            IsPublic = true;
+            Visibility = Visibility.Public;
             Name = "Expand";
             GenericParameters = new[] { "TTarget" };
             Parameters = new[]

--- a/src/Writers/CSharpWriter/GeneratedEdmModelCreateXmlReaderMethod.cs
+++ b/src/Writers/CSharpWriter/GeneratedEdmModelCreateXmlReaderMethod.cs
@@ -7,7 +7,7 @@ namespace CSharpWriter
     {
         public GeneratedEdmModelCreateXmlReaderMethod()
         {
-            IsPublic = false;
+            Visibility = Visibility.Private;
             IsStatic = true;
             Name = "CreateXmlReader";
             Parameters = new[] { new Parameter(new Type(new Identifier("System", "String")), "edmxToParse") };

--- a/src/Writers/CSharpWriter/GeneratedEdmModelGetInstanceMethod.cs
+++ b/src/Writers/CSharpWriter/GeneratedEdmModelGetInstanceMethod.cs
@@ -7,7 +7,7 @@ namespace CSharpWriter
     {
         public GeneratedEdmModelGetInstanceMethod()
         {
-            IsPublic = true;
+            Visibility = Visibility.Public;
             IsStatic = true;
             Name = "GetInstance";
             ReturnType = new Type(new Identifier("global::Microsoft.OData.Edm", "IEdmModel"));

--- a/src/Writers/CSharpWriter/GeneratedEdmModelLoadModelFromStringMethod.cs
+++ b/src/Writers/CSharpWriter/GeneratedEdmModelLoadModelFromStringMethod.cs
@@ -7,7 +7,7 @@ namespace CSharpWriter
     {
         public GeneratedEdmModelLoadModelFromStringMethod()
         {
-            IsPublic = false;
+            Visibility = Visibility.Private;
             IsStatic = true;
             Name = "LoadModelFromString";
             ReturnType = new Type(new Identifier("global::Microsoft.OData.Edm", "IEdmModel"));

--- a/src/Writers/CSharpWriter/Member.cs
+++ b/src/Writers/CSharpWriter/Member.cs
@@ -1,24 +1,18 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace CSharpWriter
 {
     public abstract class Member
     {
         public bool IsOverriding { get; protected set; }
-        public bool IsPublic { get; protected set; }
+        public Visibility Visibility { get; protected set; }
         public bool IsStatic { get; protected set; }
 
         protected Member()
         {
             IsOverriding = false;
-            IsPublic = true;
+            Visibility = Visibility.Public;
             IsStatic = false;
         }
     }

--- a/src/Writers/CSharpWriter/Methods.cs
+++ b/src/Writers/CSharpWriter/Methods.cs
@@ -14,6 +14,10 @@ namespace CSharpWriter
         {
             return Methods.ForEntityType(odcmClass);
         }
+        public static IEnumerable<Method> ForConcreteMediaInterface(OdcmClass odcmClass)
+        {
+            return Methods.ForEntityType(odcmClass);
+        }
 
         public static IEnumerable<Method> ForConcrete(OdcmClass odcmClass)
         {
@@ -70,12 +74,29 @@ namespace CSharpWriter
 
         public static IEnumerable<Method> ForCollectionInterface(OdcmClass odcmClass)
         {
+            var odcmMediaClass = odcmClass as OdcmMediaClass;
+            if (odcmMediaClass != null)
+            {
+                return ForMediaCollectionInterface(odcmMediaClass);
+            }
+
             return Methods.GetMethodsBoundToCollection(odcmClass)
                 .Concat(new Method[]
                 {
                     new CollectionGetByIdMethod(odcmClass),
                     new CollectionExecuteAsyncMethod(odcmClass),
                     new AddAsyncMethod(odcmClass)
+                });
+        }
+
+        public static IEnumerable<Method> ForMediaCollectionInterface(OdcmMediaClass odcmClass)
+        {
+            return Methods.GetMethodsBoundToCollection(odcmClass)
+                .Concat(new Method[]
+                {
+                    new CollectionGetByIdMethod(odcmClass),
+                    new CollectionExecuteAsyncMethod(odcmClass),
+                    new AddAsyncMediaMethod(odcmClass)
                 });
         }
 

--- a/src/Writers/CSharpWriter/NamesService.cs
+++ b/src/Writers/CSharpWriter/NamesService.cs
@@ -86,6 +86,7 @@ namespace CSharpWriter
                 case "Stream": return new Identifier("Microsoft.OData.Client", "DataServiceStreamLink");
                 case "String": return new Identifier("System", "String");
                 case "TimeOfDay": return new Identifier("System", "DateTimeOffset");
+                case "IStream":return new Identifier("System.IO", "Stream");
             }
 
             return null;

--- a/src/Writers/CSharpWriter/Namespace.cs
+++ b/src/Writers/CSharpWriter/Namespace.cs
@@ -18,9 +18,14 @@ namespace CSharpWriter
         public Namespace(OdcmNamespace @namespace, OdcmModel model)
         {
             Name = NamesService.GetNamespaceName(@namespace);
+            //Features = @namespace.Enums.SelectMany(global::CSharpWriter.Features.ForOdcmEnum)
+            //    .Concat(@namespace.Classes.SelectMany(global::CSharpWriter.Features.ForOdcmClass))
+            //    .Concat(@namespace.Classes.SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
             Features = @namespace.Enums.SelectMany(global::CSharpWriter.Features.ForOdcmEnum)
-                .Concat(@namespace.Classes.SelectMany(global::CSharpWriter.Features.ForOdcmClass))
+                .Concat(@namespace.ClassesOf<OdcmComplexClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
                 .Concat(@namespace.Classes.OfType<OdcmServiceClass>().SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
+                .Concat(@namespace.ClassesOf<OdcmEntityClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
+                .Concat(@namespace.ClassesOf<OdcmServiceClass>().SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
         }
     }
 }

--- a/src/Writers/CSharpWriter/Namespace.cs
+++ b/src/Writers/CSharpWriter/Namespace.cs
@@ -22,10 +22,9 @@ namespace CSharpWriter
             //    .Concat(@namespace.Classes.SelectMany(global::CSharpWriter.Features.ForOdcmClass))
             //    .Concat(@namespace.Classes.SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
             Features = @namespace.Enums.SelectMany(global::CSharpWriter.Features.ForOdcmEnum)
-                .Concat(@namespace.ClassesOf<OdcmComplexClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
+                .Concat(@namespace.Classes.OfType<OdcmComplexClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
+                .Concat(@namespace.Classes.OfType<OdcmEntityClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
                 .Concat(@namespace.Classes.OfType<OdcmServiceClass>().SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
-                .Concat(@namespace.ClassesOf<OdcmEntityClass>().SelectMany(global::CSharpWriter.Features.ForOdcmClass))
-                .Concat(@namespace.ClassesOf<OdcmServiceClass>().SelectMany(c => global::CSharpWriter.Features.ForEntityContainer(c, model)));
         }
     }
 }

--- a/src/Writers/CSharpWriter/Settings/CSharpWriterSettings.cs
+++ b/src/Writers/CSharpWriter/Settings/CSharpWriterSettings.cs
@@ -8,6 +8,7 @@ namespace CSharpWriter.Settings
         {
             OdcmNamespaceToProxyNamespace = new Dictionary<string, string>();
             OdcmClassNameToProxyClassName = new Dictionary<string, IDictionary<string, string>>();
+            MediaEntityAddAsyncVisibility = Visibility.Public;
         }
 
         public IDictionary<string, string> OdcmNamespaceToProxyNamespace { get; set; }
@@ -19,5 +20,7 @@ namespace CSharpWriter.Settings
         public bool OmitUpcastMethods { get; set; }
         
         public bool ForcePropertyPascalCasing { get; set; }
+
+        public Visibility MediaEntityAddAsyncVisibility { get; set; }
     }
 }

--- a/src/Writers/CSharpWriter/UpcastMethodBase.cs
+++ b/src/Writers/CSharpWriter/UpcastMethodBase.cs
@@ -14,8 +14,7 @@ namespace CSharpWriter
         {
             BaseType = baseType;
             DerivedType = derivedType;
-
-            IsPublic = true;
+            Visibility = Visibility.Public;
         }
     }
 }

--- a/src/Writers/CSharpWriter/Visibility.cs
+++ b/src/Writers/CSharpWriter/Visibility.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CSharpWriter
+{
+    public enum Visibility
+    {
+        Public,
+        Private,
+        Protected,
+        Internal,
+        ProtectedInternal
+    }
+}

--- a/test/CSharpWriterUnitTests/Given_a_ConfigurationProvider.cs
+++ b/test/CSharpWriterUnitTests/Given_a_ConfigurationProvider.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+using CSharpWriter;
 using CSharpWriter.Settings;
 using FluentAssertions;
 using Microsoft.Its.Recipes;
@@ -14,9 +10,13 @@ using Microsoft.MockService.Extensions.ODataV4;
 using Microsoft.OData.ProxyExtensions;
 using Microsoft.Owin;
 using Moq;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using Vipr.Core;
 using Vipr.Core.CodeModel;
 using Xunit;

--- a/test/CSharpWriterUnitTests/Given_an_OdcmClass_Complex.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmClass_Complex.cs
@@ -30,7 +30,7 @@ namespace CSharpWriterUnitTests
 
             _model.Namespaces.Add(_namespace);
 
-            _class = Any.OdcmClass(e => e.Namespace = _namespace);
+            _class = Any.OdcmComplexClass(e => e.Namespace = _namespace);
 
             _model.AddType(_class);
 

--- a/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Collection.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Collection.cs
@@ -208,8 +208,6 @@ namespace CSharpWriterUnitTests
 
 public class Given_an_OdcmClass_Entity_Uninitialized : NavigationPropertyTestBase
 {
-    private MockService _mockedService;
-
     public Given_an_OdcmClass_Entity_Uninitialized()
     {
         base.Init(m =>

--- a/test/CSharpWriterUnitTests/Given_an_OdcmClass_Service_Bound_Function_Base.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmClass_Service_Bound_Function_Base.cs
@@ -19,7 +19,6 @@ namespace CSharpWriterUnitTests
         protected OdcmMethod Method;
         protected Func<Type, Type> ReturnTypeGenerator;
         protected bool IsCollection;
-        private OdcmClass _expectedReturnClass;
         private Type _expectedReturnType;
         private string _expectedMethodName;
         private IEnumerable<Type> _expectedMethodParameters;

--- a/test/ODataReader.v4UnitTests/Any.cs
+++ b/test/ODataReader.v4UnitTests/Any.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
-using System.Runtime.Remoting.Messaging;
-using System.Xml.Linq;
 using ODataReader.v4UnitTests;
+using System;
+using System.Xml.Linq;
 
 namespace Microsoft.Its.Recipes
 {
@@ -24,7 +22,7 @@ namespace Microsoft.Its.Recipes
 
         internal static class Csdl
         {
-            private readonly static string[] PrimitiveTypes = new[]
+            private readonly static string[] PrimitiveTypes =
             {
                 "Edm.Binary",
                 "Edm.Boolean",

--- a/test/ODataReader.v4UnitTests/EdmxTestCase.cs
+++ b/test/ODataReader.v4UnitTests/EdmxTestCase.cs
@@ -1,0 +1,228 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Its.Recipes;
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Vipr.Core;
+
+namespace ODataReader.v4UnitTests
+{
+    public class EdmxTestCase
+    {
+        public class TestNode
+        {
+            public string Namespace;
+            public string Name;
+            public XElement Element;
+
+            public TestNode(string @namespace, string name, XElement element)
+            {
+                Namespace = @namespace;
+                Name = name;
+                Element = element;
+            }
+
+            public string FullName()
+            {
+                return Namespace + "." + Name;
+            }
+        }
+
+        public class Keys
+        {
+            public const string Action = "$action";
+            public const string ComplexType = "$complexType";
+            public const string ComplexTypeBase = "$complexType#Base";
+            public const string Edmx = "$edmx";
+            public const string EntityContainer = "$entityContainer";
+            public const string EntityType = "$entityType";
+            public const string EntityTypeBase = "$entityType#Base";
+            public const string EnumType = "$enumType";
+            public const string Function = "$function";
+            public const string Schema = "$schema";
+        }
+
+        private readonly Dictionary<string, TestNode> _testObjectMap = new Dictionary<string, TestNode>();
+
+        public EdmxTestCase()
+        {
+            _testObjectMap.Add(Keys.Edmx, new TestNode(string.Empty, string.Empty, Any.Csdl.EdmxToSchema(schema =>
+            {
+                var @namespace = schema.Attribute("Namespace").Value;
+                _testObjectMap.Add(Keys.Schema, new TestNode(@namespace, string.Empty, schema));
+                schema.Add(Any.Csdl.EntityContainer(entityContainer => _testObjectMap.Add(Keys.EntityContainer, new TestNode(@namespace, entityContainer.Attribute("Name").Value, entityContainer))));
+            })));
+        }
+
+        public EdmxTestCase AddEntityType(string entityTypeKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            return AddEntityType(entityTypeKey, false, config);
+        }
+
+        public EdmxTestCase AddEntityType(string entityTypeKey, bool noKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            var schema = _testObjectMap[Keys.Schema];
+
+            schema.Element.Add(Any.Csdl.EntityType(entityType =>
+            {
+                var testNode = new TestNode(schema.Namespace, entityType.Attribute("Name").Value, entityType);
+                _testObjectMap.Add(entityTypeKey, testNode);
+
+                if (!noKey)
+                {
+                    entityType.Add(Any.Csdl.Key(key =>
+                    {
+                        foreach (
+                            var property in
+                                Any.Sequence(
+                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
+                                    Any.Int(1, 2)))
+                        {
+                            entityType.Add(property);
+                            key.Add(Any.Csdl.PropertyRef(property.Attribute("Name").Value));
+                        }
+                    }));
+                }
+
+                foreach (
+                    var property in
+                        Any.Sequence(
+                            i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
+                            Any.Int(1, 3)))
+                {
+                    entityType.Add(property);
+                }
+ 
+                if (config != null)
+                {
+                    config(this, entityType);
+                }
+            }));
+
+            return this;
+        }
+
+        public EdmxTestCase AddComplexType(string complexTypeKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            var schema = _testObjectMap[Keys.Schema];
+
+            schema.Element.Add(Any.Csdl.ComplexType(complexType =>
+            {
+                var testNode = new TestNode(schema.Namespace, complexType.Attribute("Name").Value, complexType);
+                _testObjectMap.Add(complexTypeKey, testNode);
+
+                foreach (
+                    var property in
+                        Any.Sequence(
+                            i =>
+                                Any.Csdl.Property(
+                                    property => property.AddAttribute("Type", Any.Csdl.RandomPrimitiveType())),
+                            Any.Int(1, 5)))
+                {
+                    complexType.Add(property);
+                }
+
+                if (config != null)
+                {
+                    config(this,complexType);
+                }
+            }));
+
+            return this;
+        }
+
+        public EdmxTestCase AddEnumType(string enumTypeKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            var schema = _testObjectMap[Keys.Schema];
+
+            schema.Element.Add(Any.Csdl.EnumType(enumType =>
+            {
+                var testNode = new TestNode(schema.Namespace, enumType.GetAttribute("Name"), enumType);
+                _testObjectMap.Add(enumTypeKey, testNode);
+
+                foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                {
+                    enumType.Add(member);
+                }
+
+                if (config != null)
+                {
+                    config(this, enumType);
+                }
+            }));
+
+            return this;
+        }
+
+        public EdmxTestCase AddBoundAction(string actionKey, string boundEntityTypeKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            var boundEntityType = _testObjectMap[boundEntityTypeKey];
+            var schema = _testObjectMap[Keys.Schema];
+
+            schema.Element.Add(Any.Csdl.Action(Any.Csdl.RandomPrimitiveType(), action =>
+            {
+                var testNode = new TestNode(schema.Namespace, action.GetAttribute("Name"), action);
+                _testObjectMap.Add(actionKey, testNode);
+
+                action.AddAttribute("IsBound", true);
+                action.Add(Any.Csdl.Parameter(boundEntityType.FullName()));
+                foreach (
+                    var parameter in
+                        Any.Sequence(i => Any.Csdl.Parameter(Any.Csdl.RandomPrimitiveType()), Any.Int(1, 3)))
+                {
+                    action.Add(parameter);
+                }
+
+                if (config != null)
+                {
+                    config(this, action);
+                }
+            }));
+
+            return this;
+        }
+
+        public EdmxTestCase AddBoundFunction(string functionKey, string boundEntityTypeKey, Action<EdmxTestCase, XElement> config = null)
+        {
+            var boundEntityType = _testObjectMap[boundEntityTypeKey];
+            var schema = _testObjectMap[Keys.Schema];
+
+            schema.Element.Add(Any.Csdl.Function(Any.Csdl.RandomPrimitiveType(), function =>
+            {
+                var testNode = new TestNode(schema.Namespace, function.GetAttribute("Name"), function);
+                _testObjectMap.Add(functionKey, testNode);
+
+                function.AddAttribute("IsBound", true);
+                function.Add(Any.Csdl.Parameter(boundEntityType.FullName()));
+                foreach (
+                    var parameter in
+                        Any.Sequence(i => Any.Csdl.Parameter(Any.Csdl.RandomPrimitiveType()), Any.Int(1, 3)))
+                {
+                    function.Add(parameter);
+                }
+
+                if (config != null)
+                {
+                    config(this, function);
+                }
+            }));
+
+            return this;
+        }
+
+        public TestNode this[string key]
+        {
+            get { return _testObjectMap[key]; }
+        }
+
+        public TextFileCollection ServiceMetadata()
+        {
+            return new TextFileCollection
+            {
+                new TextFile("$metadata", _testObjectMap[Keys.Edmx].Element.ToString())
+            };
+        }
+    }
+}

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
-using Microsoft.Its.Recipes;
 using ODataReader.v4;
 using System;
-using System.Collections.Generic;
-using Vipr.Core;
 using Vipr.Core.CodeModel;
 using Xunit;
 
@@ -24,15 +21,9 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void It_returns_an_odcm_model()
         {
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-                schema.Add(Any.Csdl.EntityContainer()));
+            var testCase = new EdmxTestCase();
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             odcmModel
                 .Should()
@@ -42,24 +33,15 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void It_results_an_OdcmNamespace_for_the_Schema()
         {
-            var schemaNamespace = string.Empty;
+            var testCase = new EdmxTestCase();
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var schemaTestNode = testCase[EdmxTestCase.Keys.Schema];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             odcmModel.Namespaces
                 .FindAll(
-                    @namespace => @namespace.Name.Equals(schemaNamespace, StringComparison.InvariantCultureIgnoreCase))
+                    @namespace => @namespace.Name.Equals(schemaTestNode.Namespace, StringComparison.InvariantCultureIgnoreCase))
                 .Count
                 .Should()
                 .Be(1, "because only one namespace shoud be created per schema element");
@@ -68,27 +50,14 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void It_results_in_an_OdcmClass_for_the_EntityContainer()
         {
-            var schemaNamespace = string.Empty;
-            var entityContainerName = string.Empty;
+            var testCase = new EdmxTestCase();
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EntityContainer(entityContainer =>
-                {
-                    entityContainerName = entityContainer.Attribute("Name").Value;
-                }));
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var entityContainerTestNode = testCase[EdmxTestCase.Keys.EntityContainer];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmClass;
-            odcmModel.TryResolveType(entityContainerName, schemaNamespace, out odcmClass)
+            odcmModel.TryResolveType(entityContainerTestNode.Name, entityContainerTestNode.Namespace, out odcmClass)
                 .Should()
                 .BeTrue("because an EntityContainer should result in a matching OdcmType");
             odcmClass

--- a/test/ODataReader.v4UnitTests/Given_complex_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_complex_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
-using Microsoft.Its.Recipes;
 using ODataReader.v4;
-using System.Collections.Generic;
-using Vipr.Core;
+using System.Linq;
 using Vipr.Core.CodeModel;
 using Xunit;
 
@@ -21,49 +19,24 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
-        public void It_returns_one_OdcmClass_for_each_ComplexType()
+        public void It_returns_one_OdcmComplexClass_for_each_ComplexType()
         {
-            var complexTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddComplexType(EdmxTestCase.Keys.ComplexType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.ComplexType(complexType =>
-                {
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i =>
-                                    Any.Csdl.Property(
-                                        property => property.AddAttribute("Type", Any.Csdl.RandomPrimitiveType())),
-                                Any.Int(1, 5)))
-                    {
-                        complexType.Add(property);
-                        propertyCount++;
-                    }
+            var complexTypeTestNode = testCase[EdmxTestCase.Keys.ComplexType];
+            var propertyCount = (from x in complexTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Property") select x).Count();
 
-                    complexTypeName = complexType.Attribute("Name").Value;
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
-
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmComplexType;
-            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+            odcmModel.TryResolveType(complexTypeTestNode.Name, complexTypeTestNode.Namespace, out odcmComplexType)
                 .Should()
                 .BeTrue("because a complex type in the schema should result in an OdcmType");
             odcmComplexType
                 .Should()
-                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
-            odcmComplexType.As<OdcmClass>().Properties.Count
+                .BeOfType<OdcmComplexClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmComplexClass>().Properties.Count
                 .Should()
                 .Be(propertyCount, "because each property added to a complex type should result in an OdcmClass property");
         }
@@ -71,35 +44,21 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_Abstract_is_set_it_returns_an_OdcmClass_with_IsAbstract_set()
         {
-            var complexTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
+            var testCase = new EdmxTestCase()
+                .AddComplexType(EdmxTestCase.Keys.ComplexType, (_, complexType) => complexType.AddAttribute("Abstract", true));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.ComplexType(complexType =>
-                {
-                    complexTypeName = complexType.Attribute("Name").Value;
-                    complexType.AddAttribute("Abstract", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var complexTypeTestNode = testCase[EdmxTestCase.Keys.ComplexType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmComplexType;
-            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+            odcmModel.TryResolveType(complexTypeTestNode.Name, complexTypeTestNode.Namespace, out odcmComplexType)
                 .Should()
                 .BeTrue("because a complex type in the schema should result in an OdcmType");
             odcmComplexType
                 .Should()
-                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
-            odcmComplexType.As<OdcmClass>().IsAbstract
+                .BeOfType<OdcmComplexClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmComplexClass>().IsAbstract
                 .Should()
                 .BeTrue("because a complex type with the Abstract facet set should be abstract in the OdcmModel");
         }
@@ -107,35 +66,21 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_OpenType_is_set_it_returns_an_OdcmClass_with_IsOpen_set()
         {
-            var complexTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
+            var testCase = new EdmxTestCase()
+                .AddComplexType(EdmxTestCase.Keys.ComplexType, (_, complexType) => complexType.AddAttribute("OpenType", true));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.ComplexType(complexType =>
-                {
-                    complexTypeName = complexType.Attribute("Name").Value;
-                    complexType.AddAttribute("OpenType", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var complexTypeTestNode = testCase[EdmxTestCase.Keys.ComplexType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmComplexType;
-            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+            odcmModel.TryResolveType(complexTypeTestNode.Name, complexTypeTestNode.Namespace, out odcmComplexType)
                 .Should()
                 .BeTrue("because a complex type in the schema should result in an OdcmType");
             odcmComplexType
                 .Should()
-                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
-            odcmComplexType.As<OdcmClass>().IsOpen
+                .BeOfType<OdcmComplexClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmComplexClass>().IsOpen
                 .Should()
                 .BeTrue("because a complex type with the OpenType facet set should be open in the OdcmModel");
         }
@@ -143,54 +88,37 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_BaseType_is_set_it_returns_an_OdcmClass_with_a_BaseType_set()
         {
-            var baseTypeName = string.Empty;
-            var complexTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
+            var testCase = new EdmxTestCase()
+                .AddComplexType(EdmxTestCase.Keys.ComplexTypeBase, (_, complexType) => complexType.AddAttribute("Abstract", true))
+                .AddComplexType(EdmxTestCase.Keys.ComplexType, (_, complexType) => complexType.AddAttribute("BaseType", _[EdmxTestCase.Keys.ComplexTypeBase].FullName()));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.Attribute("Namespace").Value;
-                schema.Add(Any.Csdl.ComplexType(complexType =>
-                {
-                    baseTypeName = complexType.Attribute("Name").Value;
-                    complexType.AddAttribute("Abstract", true);
-                }));
-                schema.Add(Any.Csdl.ComplexType(complexType =>
-                {
-                    complexTypeName = complexType.Attribute("Name").Value;
-                    complexType.AddAttribute("BaseType", schemaNamespace + "." + baseTypeName);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var baseComplexTypeTestNode = testCase[EdmxTestCase.Keys.ComplexTypeBase];
+            var complexTypeTestNode = testCase[EdmxTestCase.Keys.ComplexType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
 
             OdcmType odcmBaseType;
-            odcmModel.TryResolveType(baseTypeName, schemaNamespace, out odcmBaseType)
+            odcmModel.TryResolveType(baseComplexTypeTestNode.Name, baseComplexTypeTestNode.Namespace, out odcmBaseType)
                 .Should()
                 .BeTrue("because a complex type in the schema should result in an OdcmType");
             odcmBaseType
                 .Should()
-                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
+                .BeOfType<OdcmComplexClass>("because complex types should result in an OdcmClass");
             OdcmType odcmComplexType;
-            odcmModel.TryResolveType(complexTypeName, schemaNamespace, out odcmComplexType)
+            odcmModel.TryResolveType(complexTypeTestNode.Name, complexTypeTestNode.Namespace, out odcmComplexType)
                 .Should()
                 .BeTrue("because a complex type in the schema should result in an OdcmType");
             odcmComplexType
                 .Should()
-                .BeOfType<OdcmClass>("because complex types should result in an OdcmClass");
-            odcmComplexType.As<OdcmClass>().Base
+                .BeOfType<OdcmComplexClass>("because complex types should result in an OdcmClass");
+            odcmComplexType.As<OdcmComplexClass>().Base
                 .Should()
                 .Be(odcmBaseType,
                     "because a complex type with a base type set should have a corresponding OdcmClass and base OdcmClass");
-            odcmBaseType.As<OdcmClass>().Derived
+            odcmBaseType.As<OdcmComplexClass>().Derived
                 .Should()
-                .Contain(odcmComplexType.As<OdcmClass>(),
+                .Contain(odcmComplexType.As<OdcmComplexClass>(),
                     "because a complex type with a base type set should have a correspond OdcmClass that derives from a base OdcmClass");
         }
     }

--- a/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
-using Microsoft.Its.Recipes;
 using ODataReader.v4;
-using System.Collections.Generic;
-using Vipr.Core;
+using System.Linq;
 using Vipr.Core.CodeModel;
 using Xunit;
-using Xunit.Sdk;
 
 namespace ODataReader.v4UnitTests
 {
@@ -24,52 +21,17 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void It_returns_one_OdcmEntityClass_for_each_EntityType()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.Attribute("Namespace").Value;
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.Attribute("Name").Value;
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.Attribute("Name").Value));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var keyCount = (from x in entityTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("PropertyRef") select x).Count();
+            var propertyCount = (from x in entityTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Property") select x).Count();
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -80,7 +42,7 @@ namespace ODataReader.v4UnitTests
                 .Be(keyCount, "because each property reference added to the key of an entity type should result in an OdcmClass property");
             odcmEntityType.As<OdcmEntityClass>().Properties.Count
                 .Should()
-                .Be(propertyCount + keyCount, "because each property added to an entity type should result in an OdcmClass property");
+                .Be(propertyCount, "because each property added to an entity type should result in an OdcmClass property");
             odcmEntityType.As<OdcmEntityClass>().IsAbstract
                 .Should()
                 .BeFalse("because an entity type with no Abstract facet should be false in the OdcmModel");
@@ -92,53 +54,15 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_Abstract_is_set_it_returns_an_OdcmEntityClass_with_IsAbstract_set()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("Abstract", true));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.Attribute("Namespace").Value;
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.Attribute("Name").Value;
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.Attribute("Name").Value));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                    entityType.AddAttribute("Abstract", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -152,53 +76,15 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_OpenType_is_set_it_returns_an_OdcmEntityClass_with_IsOpen_set()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("OpenType", true));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.Attribute("Namespace").Value;
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.Attribute("Name").Value;
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.Attribute("Name").Value));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                    entityType.AddAttribute("OpenType", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -212,53 +98,15 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_HasStream_is_set_it_returns_an_OdcmMediaClass()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("HasStream", true));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.Attribute("Namespace").Value;
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.Attribute("Name").Value;
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.Attribute("Name").Value));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                    entityType.AddAttribute("HasStream", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -267,76 +115,26 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
-        public void When_BaseType_is_set_it_returns_an_OdcmEntityClass_with_a_BaseType_set()
+        public void When_BaseType_is_set_it_returns_an_OdcmEntityClass_with_a_BaseType()
         {
-            var baseTypeName = string.Empty;
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityTypeBase, (_, entityType) => entityType.AddAttribute("Abstract", true))
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("BaseType", _[EdmxTestCase.Keys.EntityTypeBase].FullName()));
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.GetAttribute("Namespace");
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    baseTypeName = entityType.GetAttribute("Name");
-                    entityType.AddAttribute("Abstract", true);
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.GetAttribute("Name")));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.EntityType(schemaNamespace + "." + baseTypeName, entityType =>
-                {
-                    entityTypeName = entityType.GetAttribute("Name");
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var baseEntityTypeTestNode = testCase[EdmxTestCase.Keys.EntityTypeBase];
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmBaseType;
-            odcmModel.TryResolveType(baseTypeName, schemaNamespace, out odcmBaseType)
+            odcmModel.TryResolveType(baseEntityTypeTestNode.Name, baseEntityTypeTestNode.Namespace, out odcmBaseType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmBaseType
                 .Should()
                 .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -353,69 +151,155 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
+        public void When_BaseType_is_set_and_only_derived_EntityType_has_Key_it_returns_an_OdcmEntityClass_using_Key_of_derived_EntityType()
+        {
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityTypeBase, true, (_, entityType) => entityType.AddAttribute("Abstract", true))
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("BaseType", _[EdmxTestCase.Keys.EntityTypeBase].FullName()));
+
+            var baseEntityTypeTestNode = testCase[EdmxTestCase.Keys.EntityTypeBase];
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var keyCount = (from x in entityTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("PropertyRef") select x).Count();
+
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
+            OdcmType odcmBaseType;
+            odcmModel.TryResolveType(baseEntityTypeTestNode.Name, baseEntityTypeTestNode.Namespace, out odcmBaseType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmBaseType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            OdcmType odcmEntityType;
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmEntityType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Base
+                .Should()
+                .Be(odcmBaseType,
+                    "because an entity type with a base type set should have a corresponding OdcmClass and base OdcmClass");
+            odcmBaseType.As<OdcmEntityClass>().Derived
+                .Should()
+                .Contain(odcmEntityType.As<OdcmEntityClass>(),
+                    "because an entity type with a base type set should have a correspond OdcmClass that derives from a base OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Key
+                .Count().Should().Be(keyCount, "");
+            (from key in odcmEntityType.As<OdcmEntityClass>().Key
+                where
+                    (from x in entityTypeTestNode.Element.Descendants()
+                        where x.Name.LocalName.Equals("PropertyRef") && x.GetAttribute("Name").Equals(key.CanonicalName())
+                        select x).Any()
+                select key).Count().Should().Be(keyCount, "");
+        }
+
+        [Fact]
+        public void When_BaseType_is_set_and_only_base_EntityType_has_Key_it_returns_an_OdcmEntityClass_using_Key_of_base_EntityType()
+        {
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityTypeBase, (_, entityType) => entityType.AddAttribute("Abstract", true))
+                .AddEntityType(EdmxTestCase.Keys.EntityType, true, (_, entityType) => entityType.AddAttribute("BaseType", _[EdmxTestCase.Keys.EntityTypeBase].FullName()));
+
+            var baseEntityTypeTestNode = testCase[EdmxTestCase.Keys.EntityTypeBase];
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var keyCount = (from x in baseEntityTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("PropertyRef") select x).Count();
+
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
+            OdcmType odcmBaseType;
+            odcmModel.TryResolveType(baseEntityTypeTestNode.Name, baseEntityTypeTestNode.Namespace, out odcmBaseType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmBaseType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            OdcmType odcmEntityType;
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmEntityType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Base
+                .Should()
+                .Be(odcmBaseType,
+                    "because an entity type with a base type set should have a corresponding OdcmClass and base OdcmClass");
+            odcmBaseType.As<OdcmEntityClass>().Derived
+                .Should()
+                .Contain(odcmEntityType.As<OdcmEntityClass>(),
+                    "because an entity type with a base type set should have a correspond OdcmClass that derives from a base OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Key
+                .Count().Should().Be(keyCount, "");
+            (from key in odcmEntityType.As<OdcmEntityClass>().Key
+             where
+                 (from x in baseEntityTypeTestNode.Element.Descendants()
+                  where x.Name.LocalName.Equals("PropertyRef") && x.GetAttribute("Name").Equals(key.CanonicalName())
+                  select x).Any()
+             select key).Count().Should().Be(keyCount, "");
+        }
+
+        [Fact]
+        public void When_BaseType_is_set_and_both_have_Keys_it_returns_an_OdcmEntityClass_using_Key_of_derived_EntityType()
+        {
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityTypeBase, (_, entityType) => entityType.AddAttribute("Abstract", true))
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) => entityType.AddAttribute("BaseType", _[EdmxTestCase.Keys.EntityTypeBase].FullName()));
+
+            var baseEntityTypeTestNode = testCase[EdmxTestCase.Keys.EntityTypeBase];
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var keyCount = (from x in entityTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("PropertyRef") select x).Count();
+
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
+            OdcmType odcmBaseType;
+            odcmModel.TryResolveType(baseEntityTypeTestNode.Name, baseEntityTypeTestNode.Namespace, out odcmBaseType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmBaseType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            OdcmType odcmEntityType;
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
+                .Should()
+                .BeTrue("because an entity type in the schema should result in an OdcmType");
+            odcmEntityType
+                .Should()
+                .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Base
+                .Should()
+                .Be(odcmBaseType,
+                    "because an entity type with a base type set should have a corresponding OdcmClass and base OdcmClass");
+            odcmBaseType.As<OdcmEntityClass>().Derived
+                .Should()
+                .Contain(odcmEntityType.As<OdcmEntityClass>(),
+                    "because an entity type with a base type set should have a correspond OdcmClass that derives from a base OdcmClass");
+            odcmEntityType.As<OdcmEntityClass>().Key
+                .Count().Should().Be(keyCount, "");
+            (from key in odcmEntityType.As<OdcmEntityClass>().Key
+             where
+                 (from x in entityTypeTestNode.Element.Descendants()
+                  where x.Name.LocalName.Equals("PropertyRef") && x.GetAttribute("Name").Equals(key.CanonicalName())
+                  select x).Any()
+             select key).Count().Should().Be(keyCount, "");
+        }
+
+        [Fact]
         public void When_an_action_is_bound_to_an_entity_type_there_is_a_method_on_the_OdcmClass()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
-            var parameterCount = 0;
-            var actionName = string.Empty;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType)
+                .AddBoundAction(EdmxTestCase.Keys.Action, EdmxTestCase.Keys.EntityType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.GetAttribute("Namespace");
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.GetAttribute("Name");
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.GetAttribute("Name")));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.Action(Any.Csdl.RandomPrimitiveType(), action =>
-                {
-                    actionName = action.GetAttribute("Name");
-                    action.AddAttribute("IsBound", true);
-                    action.Add(Any.Csdl.Parameter(schemaNamespace + "." + entityTypeName));
-                    foreach (
-                        var parameter in
-                            Any.Sequence(i => Any.Csdl.Parameter(Any.Csdl.RandomPrimitiveType()), Any.Int(1, 3)))
-                    {
-                        action.Add(parameter);
-                        parameterCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var actionTestNode = testCase[EdmxTestCase.Keys.Action];
+            var parameterCount = (from x in actionTestNode.Element.Descendants() where x.Name.LocalName.Equals("Parameter") select x).Count() - 1;
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
-
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+            
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -423,9 +307,9 @@ namespace ODataReader.v4UnitTests
                 .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
             odcmEntityType.As<OdcmEntityClass>().Methods
                 .Should()
-                .Contain(odcmMethod => odcmMethod.Name == actionName, "because an action bound to an entity type should result in a method in the OdcmClass");
+                .Contain(odcmMethod => odcmMethod.Name == actionTestNode.Name, "because an action bound to an entity type should result in a method in the OdcmClass");
             odcmEntityType.As<OdcmEntityClass>()
-                .Methods.Find(odcmMethod => odcmMethod.Name == actionName)
+                .Methods.Find(odcmMethod => odcmMethod.Name == actionTestNode.Name)
                 .Parameters.Count
                 .Should()
                 .Be(parameterCount,
@@ -435,67 +319,18 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_a_function_is_bound_to_an_entity_type_there_is_a_method_on_the_OdcmClass()
         {
-            var entityTypeName = string.Empty;
-            var schemaNamespace = string.Empty;
-            var propertyCount = 0;
-            var keyCount = 0;
-            var parameterCount = 0;
-            var functionName = string.Empty;
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType)
+                .AddBoundFunction(EdmxTestCase.Keys.Function, EdmxTestCase.Keys.EntityType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schemaNamespace = schema.GetAttribute("Namespace");
-                schema.Add(Any.Csdl.EntityType(entityType =>
-                {
-                    entityTypeName = entityType.GetAttribute("Name");
-                    entityType.Add(Any.Csdl.Key(key =>
-                    {
-                        foreach (
-                            var property in
-                                Any.Sequence(
-                                    i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType(), false),
-                                    Any.Int(1, 2)))
-                        {
-                            entityType.Add(property);
-                            key.Add(Any.Csdl.PropertyRef(property.GetAttribute("Name")));
-                            keyCount++;
-                        }
-                    }));
-                    foreach (
-                        var property in
-                            Any.Sequence(
-                                i => Any.Csdl.Property(Any.Csdl.RandomPrimitiveType()),
-                                Any.Int(1, 3)))
-                    {
-                        entityType.Add(property);
-                        propertyCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.Function(Any.Csdl.RandomPrimitiveType(), function =>
-                {
-                    functionName = function.GetAttribute("Name");
-                    function.AddAttribute("IsBound", true);
-                    function.Add(Any.Csdl.Parameter(schemaNamespace + "." + entityTypeName));
-                    foreach (
-                        var parameter in
-                            Any.Sequence(i => Any.Csdl.Parameter(Any.Csdl.RandomPrimitiveType()), Any.Int(1, 3)))
-                    {
-                        function.Add(parameter);
-                        parameterCount++;
-                    }
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-            });
+            var entityTypeTestNode = testCase[EdmxTestCase.Keys.EntityType];
+            var functionTestNode = testCase[EdmxTestCase.Keys.Function];
+            var parameterCount = (from x in functionTestNode.Element.Descendants() where x.Name.LocalName.Equals("Parameter") select x).Count() - 1;
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
 
             OdcmType odcmEntityType;
-            odcmModel.TryResolveType(entityTypeName, schemaNamespace, out odcmEntityType)
+            odcmModel.TryResolveType(entityTypeTestNode.Name, entityTypeTestNode.Namespace, out odcmEntityType)
                 .Should()
                 .BeTrue("because an entity type in the schema should result in an OdcmType");
             odcmEntityType
@@ -503,9 +338,9 @@ namespace ODataReader.v4UnitTests
                 .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmClass");
             odcmEntityType.As<OdcmEntityClass>().Methods
                 .Should()
-                .Contain(odcmMethod => odcmMethod.Name == functionName, "because a function bound to an entity type should result in a method in the OdcmClass");
+                .Contain(odcmMethod => odcmMethod.Name == functionTestNode.Name, "because a function bound to an entity type should result in a method in the OdcmClass");
             odcmEntityType.As<OdcmEntityClass>()
-                .Methods.Find(odcmMethod => odcmMethod.Name == functionName)
+                .Methods.Find(odcmMethod => odcmMethod.Name == functionTestNode.Name)
                 .Parameters.Count
                 .Should()
                 .Be(parameterCount,

--- a/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -287,7 +287,7 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
-        public void When_BaseType_blah()
+        public void When_a_Property_references_a_ComplexType_it_returns_an_OdcmEntityClass_with_a_property_having_the_corresponding_OdcmComplexType()
         {
             string complexTypePropertyName = string.Empty;
 
@@ -322,11 +322,11 @@ namespace ODataReader.v4UnitTests
                 .BeOfType<OdcmEntityClass>("because entity types should result in an OdcmEntityClass");
             var complexProperty = (from property in odcmEntityType.As<OdcmEntityClass>().Properties
                                    where property.Name.Equals(complexTypePropertyName)
-                                   select property);
-            complexProperty.Count()
+                                   select property).FirstOrDefault();
+            complexProperty
                 .Should()
-                .Be(1, "because a property referencing a complex type should result in a property in the OdcmEntityClass");
-            complexProperty.First().Type
+                .NotBeNull("because a property referencing a complex type should result in a property in the OdcmEntityClass");
+            complexProperty.Type
                 .Should()
                 .Be(odcmComplexType, "because a property referencing a complex type should result in a property with a type matching the OdcmComplexClass of the property");
         }

--- a/test/ODataReader.v4UnitTests/Given_enum_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_enum_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -5,8 +5,7 @@ using FluentAssertions;
 using Microsoft.Its.Recipes;
 using ODataReader.v4;
 using System;
-using System.Collections.Generic;
-using Vipr.Core;
+using System.Linq;
 using Vipr.Core.CodeModel;
 using Xunit;
 
@@ -24,34 +23,16 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void It_returns_one_OdcmType_for_each_EnumType()
         {
-            var schemaNamespace = string.Empty;
-            var enumName = string.Empty;
-            var enumMemberCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEnumType(EdmxTestCase.Keys.EnumType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EnumType(enumType =>
-                {
-                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
-                    {
-                        enumType.Add(member);
-                        enumMemberCount++;
-                    }
-                    enumName = enumType.Attribute("Name").Value;
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var enumTypeTestNode = testCase[EdmxTestCase.Keys.EnumType];
+            var enumMemberCount = (from x in enumTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Member") select x).Count();
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmEnum;
-            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+            odcmModel.TryResolveType(enumTypeTestNode.Name, enumTypeTestNode.Namespace, out odcmEnum)
                 .Should()
                 .BeTrue("because an enum type in the schema should result in an OdcmType");
             odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
@@ -63,36 +44,27 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_IsFlags_is_set_it_returns_an_OdcmEnum_with_IsFlags_set()
         {
-            var schemaNamespace = string.Empty;
-            var enumName = string.Empty;
-            var enumMemberCount = 0;
-
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EnumType(enumType =>
+            var testCase = new EdmxTestCase()
+                .AddEnumType(EdmxTestCase.Keys.EnumType, (_, enumType) =>
                 {
-                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
+                    var count = 0;
+                    foreach (var descendent in enumType.Descendants())
                     {
-                        member.AddAttribute("Value", (int)Math.Pow(enumMemberCount, 2));
-                        enumType.Add(member);
-                        enumMemberCount++;
+                        if (descendent.Name.LocalName.Equals("Member"))
+                        {
+                            descendent.AddAttribute("Value", (int)Math.Pow(count++, 2));
+                        }
                     }
-                    enumName = enumType.Attribute("Name").Value;
                     enumType.AddAttribute("IsFlags", true);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+                });
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
+            var enumTypeTestNode = testCase[EdmxTestCase.Keys.EnumType];
+            var enumMemberCount = (from x in enumTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Member") select x).Count();
 
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmEnum;
-            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+            odcmModel.TryResolveType(enumTypeTestNode.Name, enumTypeTestNode.Namespace, out odcmEnum)
                 .Should()
                 .BeTrue("because an enum type in the schema should result in an OdcmType");
             odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
@@ -108,34 +80,16 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_No_Underlying_Type_is_set_it_returns_an_OdcmEnum_with_a_Default_UnderlyingType()
         {
-            var schemaNamespace = string.Empty;
-            var enumName = string.Empty;
-            var enumMemberCount = 0;
+            var testCase = new EdmxTestCase()
+                .AddEnumType(EdmxTestCase.Keys.EnumType);
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EnumType(enumType =>
-                {
-                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
-                    {
-                        enumType.Add(member);
-                        enumMemberCount++;
-                    }
-                    enumName = enumType.Attribute("Name").Value;
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var enumTypeTestNode = testCase[EdmxTestCase.Keys.EnumType];
+            var enumMemberCount = (from x in enumTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Member") select x).Count();
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
-
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmEnum;
-            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+            odcmModel.TryResolveType(enumTypeTestNode.Name, enumTypeTestNode.Namespace, out odcmEnum)
                 .Should()
                 .BeTrue("because an enum type in the schema should result in an OdcmType");
             odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");
@@ -151,37 +105,18 @@ namespace ODataReader.v4UnitTests
         [Fact]
         public void When_An_Underlying_Type_is_set_it_returns_an_OdcmEnum_with_the_specified_UnderlyingType()
         {
-            var schemaNamespace = string.Empty;
-            var enumName = string.Empty;
-            var enumMemberCount = 0;
-            var underlyingType = string.Empty;
+            var underlyingType = Any.Csdl.RandomEnumUnderlyingType();
 
-            var edmxElement = Any.Csdl.EdmxToSchema(schema =>
-            {
-                schema.Add(Any.Csdl.EnumType(enumType =>
-                {
-                    foreach (var member in Any.Sequence((i) => Any.Csdl.Member(), Any.Int(1, 5)))
-                    {
-                        enumType.Add(member);
-                        enumMemberCount++;
-                    }
-                    enumName = enumType.Attribute("Name").Value;
-                    underlyingType = Any.Csdl.RandomEnumUnderlyingType();
-                    enumType.AddAttribute("UnderlyingType", underlyingType);
-                }));
-                schema.Add(Any.Csdl.EntityContainer());
-                schemaNamespace = schema.Attribute("Namespace").Value;
-            });
+            var testCase = new EdmxTestCase()
+                .AddEnumType(EdmxTestCase.Keys.EnumType, (_, enumType) => enumType.AddAttribute("UnderlyingType", underlyingType));
 
-            var serviceMetadata = new TextFileCollection
-            {
-                new TextFile("$metadata", edmxElement.ToString())
-            };
+            var enumTypeTestNode = testCase[EdmxTestCase.Keys.EnumType];
+            var enumMemberCount = (from x in enumTypeTestNode.Element.Descendants() where x.Name.LocalName.Equals("Member") select x).Count();
 
-            var odcmModel = _odcmReader.GenerateOdcmModel(serviceMetadata);
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
 
             OdcmType odcmEnum;
-            odcmModel.TryResolveType(enumName, schemaNamespace, out odcmEnum)
+            odcmModel.TryResolveType(enumTypeTestNode.Name, enumTypeTestNode.Namespace, out odcmEnum)
                 .Should()
                 .BeTrue("because an enum type in the schema should result in an OdcmType");
             odcmEnum.Should().BeOfType<OdcmEnum>("because an enum type in the schema should result in an OdcmEnum");

--- a/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
+++ b/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
@@ -77,6 +77,7 @@
       <Link>%28Its.Recipes%29\TestInputGenerator.cs</Link>
     </Compile>
     <Compile Include="Any.cs" />
+    <Compile Include="EdmxTestCase.cs" />
     <Compile Include="Given_complex_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/test/ODataReader.v4UnitTests/XElementExtensions.cs
+++ b/test/ODataReader.v4UnitTests/XElementExtensions.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Xml.Linq;
 
 namespace ODataReader.v4UnitTests

--- a/test/Shared/(Its.Recipes)/Any.Odcm.cs
+++ b/test/Shared/(Its.Recipes)/Any.Odcm.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Its.Recipes
 
         public static OdcmMediaClass MediaOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmEntityClass> config = null)
         {
-            var retVal = new OdcmMediaClass(Any.CSharpIdentifier(), odcmNamespace.Name);
+            var retVal = new OdcmMediaClass(Any.CSharpIdentifier(), odcmNamespace);
 
             EntityOrMediaOdcmClass(odcmNamespace, config, retVal);
 

--- a/test/Shared/(Its.Recipes)/Any.Odcm.cs
+++ b/test/Shared/(Its.Recipes)/Any.Odcm.cs
@@ -49,8 +49,17 @@ namespace Microsoft.Its.Recipes
 
             retVal.Types.AddRange(Any.Sequence(s => Any.ComplexOdcmClass(retVal)));
 
-            var classes = Any.Sequence(s => Any.EntityOdcmClass(retVal)).ToArray();
+            var classes = Any.Sequence(s => Any.EntityOdcmClass(retVal))
+                .Concat(Any.Sequence(s => Any.MediaOdcmClass(retVal), count: 2)).ToArray();
 
+            foreach (var @class in (from @class in retVal.Types where @class is OdcmEntityClass select @class as OdcmEntityClass))
+            {
+                @class.Properties.AddRange(Any.Sequence(i => Any.OdcmProperty(p =>
+                {
+                    p.Class = @class;
+                    p.Type = classes.RandomElement();
+                })));
+            }
             foreach (var @class in classes)
             {
                 @class.Properties.AddRange(Any.Sequence(i => Any.OdcmProperty(p =>
@@ -84,9 +93,9 @@ namespace Microsoft.Its.Recipes
             return retVal;
         }
 
-        public static OdcmClass OdcmClass(Action<OdcmClass> config = null)
+        public static OdcmComplexClass OdcmComplexClass(Action<OdcmClass> config = null)
         {
-            var retVal = new OdcmClass(Any.CSharpIdentifier(), Any.OdcmNamespace());
+            var retVal = new OdcmComplexClass(Any.CSharpIdentifier(), Any.OdcmNamespace());
 
             if (config != null) config(retVal);
 
@@ -121,10 +130,9 @@ namespace Microsoft.Its.Recipes
             return retVal;
         }
 
-
-        public static OdcmClass ComplexOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmClass> config = null)
+        public static OdcmComplexClass ComplexOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmClass> config = null)
         {
-            var retVal = new OdcmClass(Any.CSharpIdentifier(), odcmNamespace);
+            var retVal = new OdcmComplexClass(Any.CSharpIdentifier(), odcmNamespace);
 
             retVal.Properties.AddRange(Any.Sequence(i => Any.PrimitiveOdcmProperty(p => p.Class = retVal)));
 
@@ -166,10 +174,26 @@ namespace Microsoft.Its.Recipes
             return retVal;
         }
 
+        public static OdcmMediaClass MediaOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmEntityClass> config = null)
+        {
+            var retVal = new OdcmMediaClass(Any.CSharpIdentifier(), odcmNamespace.Name);
+
+            EntityOrMediaOdcmClass(odcmNamespace, config, retVal);
+
+            return retVal;
+        }
+
         public static OdcmEntityClass EntityOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmEntityClass> config = null)
         {
             var retVal = new OdcmEntityClass(Any.CSharpIdentifier(), odcmNamespace);
 
+            EntityOrMediaOdcmClass(odcmNamespace, config, retVal);
+
+            return retVal;
+        }
+
+        private static void EntityOrMediaOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmEntityClass> config, OdcmEntityClass retVal)
+        {
             retVal.Properties.AddRange(Any.Sequence(i => Any.PrimitiveOdcmProperty(p => p.Class = retVal)));
 
             retVal.Key.AddRange(retVal.Properties.RandomSubset(2));
@@ -183,17 +207,15 @@ namespace Microsoft.Its.Recipes
 
             retVal.Properties.AddRange(Any.Sequence(i => Any.OdcmEntityProperty(retVal, p => { p.Class = retVal; })));
 
-            retVal.Properties.AddRange(Any.Sequence(i => Any.OdcmEntityProperty(retVal, p => 
-            { 
+            retVal.Properties.AddRange(Any.Sequence(i => Any.OdcmEntityProperty(retVal, p =>
+            {
                 p.Class = retVal;
                 p.IsCollection = true;
             })));
-            
+
             if (config != null) config(retVal);
 
             retVal.Methods.AddRange(Any.Sequence(s => Any.OdcmMethod()));
-
-            return retVal;
         }
 
         public static OdcmServiceClass ServiceOdcmClass(OdcmNamespace odcmNamespace, Action<OdcmServiceClass> config = null)
@@ -284,7 +306,6 @@ namespace Microsoft.Its.Recipes
 
             return retVal;
         }
-
 
         public static OdcmModel OdcmModel(Action<OdcmModel> config = null)
         {

--- a/test/Shared/ODataV4TestClient/ODataV4TestClient.cs
+++ b/test/Shared/ODataV4TestClient/ODataV4TestClient.cs
@@ -35,8 +35,8 @@ namespace ODataV4TestClient.Extensions
 
     public interface IEntityBase
     {
-        global::System.Threading.Tasks.Task UpdateAsync(bool dontSave = false);
-        global::System.Threading.Tasks.Task DeleteAsync(bool dontSave = false);
+        global::System.Threading.Tasks.Task UpdateAsync(bool deferSaveChanges = false);
+        global::System.Threading.Tasks.Task DeleteAsync(bool deferSaveChanges = false);
     }
 
     internal class RestShallowObjectFetcher : BaseEntityType
@@ -935,21 +935,21 @@ namespace ODataV4TestClient.Extensions
             return uri;
         }
 
-        public global::System.Threading.Tasks.Task UpdateAsync(bool dontSave = false)
+        public global::System.Threading.Tasks.Task UpdateAsync(bool deferSaveChanges = false)
         {
             Context.UpdateObject(this);
-            return SaveAsNeeded(dontSave);
+            return SaveAsNeeded(deferSaveChanges);
         }
 
-        public global::System.Threading.Tasks.Task DeleteAsync(bool dontSave = false)
+        public global::System.Threading.Tasks.Task DeleteAsync(bool deferSaveChanges = false)
         {
             Context.DeleteObject(this);
-            return SaveAsNeeded(dontSave);
+            return SaveAsNeeded(deferSaveChanges);
         }
 
-        protected internal global::System.Threading.Tasks.Task SaveAsNeeded(bool dontSave)
+        protected internal global::System.Threading.Tasks.Task SaveAsNeeded(bool deferSaveChanges)
         {
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -1617,7 +1617,7 @@ namespace ODataV4TestClient.Extensions
     {
         string ContentType { get; }
         global::System.Threading.Tasks.Task<global::Microsoft.OData.Client.DataServiceStreamResponse> DownloadAsync();
-        global::System.Threading.Tasks.Task UploadAsync(global::System.IO.Stream stream, string contentType, bool dontSave = false, bool closeStream = false);
+        global::System.Threading.Tasks.Task UploadAsync(global::System.IO.Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false);
     }
 
     internal class StreamFetcher : IStreamFetcher
@@ -1643,7 +1643,7 @@ namespace ODataV4TestClient.Extensions
             _propertyName = propertyName;
         }
 
-        public global::System.Threading.Tasks.Task UploadAsync(global::System.IO.Stream stream, string contentType, bool dontSave = false, bool closeStream = false)
+        public global::System.Threading.Tasks.Task UploadAsync(global::System.IO.Stream stream, string contentType, bool deferSaveChanges = false, bool closeStream = false)
         {
             var args = new global::Microsoft.OData.Client.DataServiceRequestArgs
             {
@@ -1659,7 +1659,7 @@ namespace ODataV4TestClient.Extensions
 
             _entity.OnPropertyChanged(_propertyName);
 
-            return _entity.SaveAsNeeded(dontSave);
+            return _entity.SaveAsNeeded(deferSaveChanges);
         }
 
         public global::System.Threading.Tasks.Task<global::Microsoft.OData.Client.DataServiceStreamResponse> DownloadAsync()
@@ -2937,7 +2937,7 @@ namespace ODataV4TestClient
             return base.ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task AddProductAsync(IProduct item, bool dontSave = false)
+        public global::System.Threading.Tasks.Task AddProductAsync(IProduct item, bool deferSaveChanges = false)
         {
             if (_entity == null)
             {
@@ -2950,7 +2950,7 @@ namespace ODataV4TestClient
                 Context.AddRelatedObject(_entity, shortPath, item);
             }
 
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -2975,7 +2975,7 @@ namespace ODataV4TestClient
 
         global::System.Threading.Tasks.Task<IPagedCollection<IProduct>> ExecuteAsync();
 
-        global::System.Threading.Tasks.Task AddProductAsync(IProduct item, bool dontSave = false);
+        global::System.Threading.Tasks.Task AddProductAsync(IProduct item, bool deferSaveChanges = false);
     }
 
     internal partial class SuppliedProductCollection : ODataV4TestClient.Extensions.QueryableSet<ISuppliedProduct>, ISuppliedProductCollection
@@ -3012,7 +3012,7 @@ namespace ODataV4TestClient
             return base.ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task AddSuppliedProductAsync(ISuppliedProduct item, bool dontSave = false)
+        public global::System.Threading.Tasks.Task AddSuppliedProductAsync(ISuppliedProduct item, bool deferSaveChanges = false)
         {
             if (_entity == null)
             {
@@ -3025,7 +3025,7 @@ namespace ODataV4TestClient
                 Context.AddRelatedObject(_entity, shortPath, item);
             }
 
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -3050,7 +3050,7 @@ namespace ODataV4TestClient
 
         global::System.Threading.Tasks.Task<IPagedCollection<ISuppliedProduct>> ExecuteAsync();
 
-        global::System.Threading.Tasks.Task AddSuppliedProductAsync(ISuppliedProduct item, bool dontSave = false);
+        global::System.Threading.Tasks.Task AddSuppliedProductAsync(ISuppliedProduct item, bool deferSaveChanges = false);
     }
 
     internal partial class SupplierCollection : ODataV4TestClient.Extensions.QueryableSet<ISupplier>, ISupplierCollection
@@ -3087,7 +3087,7 @@ namespace ODataV4TestClient
             return base.ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task AddSupplierAsync(ISupplier item, bool dontSave = false)
+        public global::System.Threading.Tasks.Task AddSupplierAsync(ISupplier item, bool deferSaveChanges = false)
         {
             if (_entity == null)
             {
@@ -3100,7 +3100,7 @@ namespace ODataV4TestClient
                 Context.AddRelatedObject(_entity, shortPath, item);
             }
 
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -3125,7 +3125,7 @@ namespace ODataV4TestClient
 
         global::System.Threading.Tasks.Task<IPagedCollection<ISupplier>> ExecuteAsync();
 
-        global::System.Threading.Tasks.Task AddSupplierAsync(ISupplier item, bool dontSave = false);
+        global::System.Threading.Tasks.Task AddSupplierAsync(ISupplier item, bool deferSaveChanges = false);
     }
 
     internal partial class AccountCollection : ODataV4TestClient.Extensions.QueryableSet<IAccount>, IAccountCollection
@@ -3162,7 +3162,7 @@ namespace ODataV4TestClient
             return base.ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task AddAccountAsync(IAccount item, bool dontSave = false)
+        public global::System.Threading.Tasks.Task AddAccountAsync(IAccount item, bool deferSaveChanges = false)
         {
             if (_entity == null)
             {
@@ -3175,7 +3175,7 @@ namespace ODataV4TestClient
                 Context.AddRelatedObject(_entity, shortPath, item);
             }
 
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -3200,7 +3200,7 @@ namespace ODataV4TestClient
 
         global::System.Threading.Tasks.Task<IPagedCollection<IAccount>> ExecuteAsync();
 
-        global::System.Threading.Tasks.Task AddAccountAsync(IAccount item, bool dontSave = false);
+        global::System.Threading.Tasks.Task AddAccountAsync(IAccount item, bool deferSaveChanges = false);
     }
 
     internal partial class PaymentInstrumentCollection : ODataV4TestClient.Extensions.QueryableSet<IPaymentInstrument>, IPaymentInstrumentCollection
@@ -3237,7 +3237,7 @@ namespace ODataV4TestClient
             return base.ExecuteAsyncInternal();
         }
 
-        public global::System.Threading.Tasks.Task AddPaymentInstrumentAsync(IPaymentInstrument item, bool dontSave = false)
+        public global::System.Threading.Tasks.Task AddPaymentInstrumentAsync(IPaymentInstrument item, bool deferSaveChanges = false)
         {
             if (_entity == null)
             {
@@ -3250,7 +3250,7 @@ namespace ODataV4TestClient
                 Context.AddRelatedObject(_entity, shortPath, item);
             }
 
-            if (!dontSave)
+            if (!deferSaveChanges)
             {
                 return Context.SaveChangesAsync();
             }
@@ -3275,7 +3275,7 @@ namespace ODataV4TestClient
 
         global::System.Threading.Tasks.Task<IPagedCollection<IPaymentInstrument>> ExecuteAsync();
 
-        global::System.Threading.Tasks.Task AddPaymentInstrumentAsync(IPaymentInstrument item, bool dontSave = false);
+        global::System.Threading.Tasks.Task AddPaymentInstrumentAsync(IPaymentInstrument item, bool deferSaveChanges = false);
     }
 }
 


### PR DESCRIPTION
Code clean up in ProxyExtensions.
Add MediaEntityBase to ProxyExtensions.
Add AddAsyncMediaMethod to CSharpWriter.
Propagate code clean up from ProxyExtensions into CSharpWriter.
Add Visibility enumeration to Member in CSharpWriter.
Add EdmxTestCase class to simplify creating Edmx documents for ODataReader.v4UnitTests.
Update EdmxTestCase to use TextFileCollection after rebase on to upstream/master.
Add OdcmComplexClass derivation of OdcmClass so as to allow consumer's to use strong typing to control code generation. The OdcmClassKind enumeration remains to allow walking an OdcmNamespace using a weak typing strategy.
Modified EdmxTestCase and corresponding test cases to allow for a fluent API calling strategy.
Added ConfigurationSettings (and unit tests) to control visibility of Media Entity AddAsync methods to allow for custom media entity creation.
Rename Complex type unit test to reflect OdcmComplexClass change.
