### PR TITLE
prefix namespace with global::

### DIFF
--- a/src/Writers/CSharpWriter/NamesService.cs
+++ b/src/Writers/CSharpWriter/NamesService.cs
@@ -217,7 +217,7 @@ namespace CSharpWriter
 
         private static Identifier ResolveIdentifier(string @namespace, string name)
         {
-            var resolvedNamespace = ResolveNamespace(@namespace);
+            var resolvedNamespace = "global::" + ResolveNamespace(@namespace);
 
             var resolvedName = ResolveName(@namespace, name);
 


### PR DESCRIPTION
Our proxy does not compile because references to types within the generated namespace were prefixed with the namespace, and therefore did not resolve. Eg:

namespace foo
{
   public class bar
   {}

   public class dink
   {
       private foo.bar _theBar;   <--- this type will be interpreted as foo.foo.bar and will not resolve


The fix makes the namespace reference absolute by prefixing it with global::