### PR TITLE
Remove the parsing of annotations by 'ODataVocabularyReader'.

### DIFF
--- a/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
@@ -114,7 +114,6 @@ namespace Vipr.Reader.OData.v4
 
             private void AddVocabularyAnnotations(OdcmObject odcmObject, IEdmVocabularyAnnotatable annotatableEdmEntity)
             {
-                odcmObject.Annotations = ODataVocabularyReader.GetOdcmAnnotations(_edmModel, annotatableEdmEntity).ToList();
                 odcmObject.Description = _edmModel.GetDescriptionAnnotation(annotatableEdmEntity);
                 odcmObject.LongDescription = _edmModel.GetLongDescriptionAnnotation(annotatableEdmEntity);
             }

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_annotations.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_annotations.cs
@@ -17,7 +17,7 @@ namespace ODataReader.v4UnitTests
     {
         // TODO: At the moment, the sample edmx does not have annotations on the sites of all items which can be annotated.
         // It may be expedient to automatically generate these sorts of documents for different test cases. 
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/Vipr/issues/84")]
         public void InsertRestrictions_should_be_properly_parsed()
         {
             OdcmReader odata4Reader = new OdcmReader();
@@ -36,7 +36,7 @@ namespace ODataReader.v4UnitTests
             annotationValue.NonInsertableNavigationProperties.Should().HaveCount(1).And.Contain("sectionGroups");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/Vipr/issues/84")]
         public void UpdateRestrictions_should_be_properly_parsed()
         {
             OdcmReader odata4Reader = new OdcmReader();
@@ -55,7 +55,7 @@ namespace ODataReader.v4UnitTests
             annotationValue.NonUpdatableNavigationProperties.Should().HaveCount(2).And.Contain("sectionGroups").And.Contain("sections");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/Microsoft/Vipr/issues/84")]
         public void DeleteRestrictions_should_be_properly_parsed()
         {
             OdcmReader odata4Reader = new OdcmReader();


### PR DESCRIPTION
ODataVocabularyReader does not gracefully fail for unknown annotations. It aggressively throws exceptions whenever it encounters annotations it is unable to parse. "ODataVocabularyReader.GetOdcmAnnotations" parses and creates a list of 'OdcmVocabularyAnnotation'. But this list not currently used by the odcmwriters to do anything useful. So I have removed the call to "ODataVocabularyReader.GetOdcmAnnotations" as a workaround. We can add this call to parse annotations once it is stable enough to handle unknown annotations. See issue #84.