### PR TITLE
X-ClientService-ClientTag for OutlookServices sample

### DIFF
--- a/samples/OutlookServices/src/ExchangeClient.Partial.cs
+++ b/samples/OutlookServices/src/ExchangeClient.Partial.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Office365.OutlookServices
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.Office365.OutlookServices
 {
     partial interface IUserFetcher
     {
@@ -171,6 +174,14 @@
             query = query.AddQueryOption("endDateTime", endDateTime.ToString(DateTimeOffsetZuluFormat));
 
             return new EventCollection(query, Context, this, path);
+        }
+    }
+
+    public partial class OutlookServicesClient
+    {
+        partial void OnContextCreated()
+        {
+            Context.BuildingRequest += (sender, args) => args.Headers.Add("X-ClientService-ClientTag", String.Format("Office 365 API Tools {0}", "1.0.33.0"));
         }
     }
 }

--- a/samples/OutlookServices/src/Microsoft.Office365.OutlookServices.csproj
+++ b/samples/OutlookServices/src/Microsoft.Office365.OutlookServices.csproj
@@ -90,11 +90,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\packages\Vipr.CommandLineInterface.1.0.5589.29130\Build\Vipr.CommandLineInterface.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Vipr.CommandLineInterface.1.0.5589.29130\Build\Vipr.CommandLineInterface.targets'))" />
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\packages\Vipr.CommandLineInterface.1.0.5589.29130\Build\Vipr.CommandLineInterface.targets" Condition="Exists('..\packages\Vipr.CommandLineInterface.1.0.5589.29130\Build\Vipr.CommandLineInterface.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/samples/OutlookServices/src/packages.config
+++ b/samples/OutlookServices/src/packages.config
@@ -5,5 +5,4 @@
   <package id="Microsoft.OData.Edm" version="6.11.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Microsoft.OData.ProxyExtensions" version="1.0.30" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
   <package id="Microsoft.Spatial" version="6.11.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Vipr.CommandLineInterface" version="1.0.5589.29130" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Also removing Vipr NuGet reference until a stable build is hosted on a MyGet feed. This prevents build issues when moving across machines.