### PR TITLE
Fix for EmtityCollectionImpl.

### DIFF
--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/EntityCollectionImpl.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions/EntityCollectionImpl.cs
@@ -22,7 +22,13 @@ namespace Microsoft.OData.ProxyExtensions
 
         protected override void InsertItem(int index, T item)
         {
-            InvokeOnEntity(t => t.Item1.Context.AddRelatedObject(t.Item1, t.Item2, item));
+            InvokeOnEntity(t =>
+            {
+                if (t.Item1.Context.GetEntityDescriptor(item) == null)
+                    t.Item1.Context.AddRelatedObject(t.Item1, t.Item2, item);
+                else
+                    t.Item1.Context.AddLink(t.Item1, t.Item2, item);
+            });
 
             base.InsertItem(index, item);
         }
@@ -52,9 +58,11 @@ namespace Microsoft.OData.ProxyExtensions
             InvokeOnEntity(t =>
             {
                 t.Item1.Context.DeleteLink(t.Item1, t.Item2, this[index]);
-                t.Item1.Context.AddRelatedObject(t.Item1, t.Item2, item);
-            }
-                );
+                if (t.Item1.Context.GetEntityDescriptor(item) == null)
+                    t.Item1.Context.AddRelatedObject(t.Item1, t.Item2, item);
+                else
+                    t.Item1.Context.AddLink(t.Item1, t.Item2, item);
+            });
 
             base.SetItem(index, item);
         }


### PR DESCRIPTION
If item to be added/replaced in an entity's navigation collection is already tracked by the OData client library, then Context.AddLink should be used instead of Context.AddRelatedObject.