### PR TITLE
Add methods SetAsync/UpdateLinkAsync/DeleteLinkAsync to the Fetcher Classes

### DIFF
--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherDeleteLinkMethod.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherDeleteLinkMethod.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Vipr.Core.CodeModel;
+
+namespace Vipr.Writer.CSharp.Lite
+{
+    public class FetcherDeleteLinkMethod : Method
+    {
+        public OdcmClass OdcmClass { get; private set; }
+
+        private FetcherDeleteLinkMethod(OdcmClass odcmClass)
+        {
+            Visibility = Visibility.Public;
+            IsOverriding = odcmClass.Base is OdcmClass && !((OdcmClass)odcmClass.Base).IsAbstract;
+            Name = "DeleteLinkAsync";
+            Parameters = new[]
+            {
+                new Parameter(new Type(new Identifier("System", "Object")), "source"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "deferSaveChanges", "false")
+            };
+            ReturnType = new Type(Identifier.Task);
+            OdcmClass = odcmClass;
+        }
+
+        public static FetcherDeleteLinkMethod ForFetcher(OdcmClass odcmClass)
+        {
+            return new FetcherDeleteLinkMethod(odcmClass);
+        }
+    }
+}

--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherSetMethod.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherSetMethod.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Vipr.Core.CodeModel;
+
+namespace Vipr.Writer.CSharp.Lite
+{
+    public class FetcherSetMethod : Method
+    {
+        public OdcmClass OdcmClass { get; private set; }
+
+        private FetcherSetMethod(OdcmClass odcmClass)
+        {
+            Visibility = Visibility.Public;
+            Name = "SetAsync";
+            Parameters = new[]
+            {
+                new Parameter(new Type(new Identifier("System", "Object")), "source"),
+                new Parameter(new Type(NamesService.GetConcreteInterfaceName(odcmClass)), "target"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "deferSaveChanges", "false")
+            };
+            ReturnType = new Type(Identifier.Task);
+            OdcmClass = odcmClass;
+        }
+
+        public static FetcherSetMethod ForFetcher(OdcmClass odcmClass)
+        {
+            return new FetcherSetMethod(odcmClass);
+        }
+    }
+}

--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherUpdateLinkMethod.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherUpdateLinkMethod.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Vipr.Core.CodeModel;
+
+namespace Vipr.Writer.CSharp.Lite
+{
+    public class FetcherUpdateLinkMethod : Method
+    {
+        public OdcmClass OdcmClass { get; private set; }
+
+        private FetcherUpdateLinkMethod(OdcmClass odcmClass)
+        {
+            Visibility = Visibility.Public;
+            Name = "UpdateLinkAsync";
+            Parameters = new[]
+            {
+                new Parameter(new Type(new Identifier("System", "Object")), "source"),
+                new Parameter(new Type(NamesService.GetConcreteInterfaceName(odcmClass)), "target"),
+                new Parameter(new Type(NamesService.GetPrimitiveTypeName("Boolean")), "deferSaveChanges", "false")
+            };
+            ReturnType = new Type(Identifier.Task);
+            OdcmClass = odcmClass;
+        }
+
+        public static FetcherUpdateLinkMethod ForFetcher(OdcmClass odcmClass)
+        {
+            return new FetcherUpdateLinkMethod(odcmClass);
+        }
+    }
+}

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Methods.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Methods.cs
@@ -37,7 +37,10 @@ namespace Vipr.Writer.CSharp.Lite
                 retVal.Add(new FetcherExecuteAsyncMethod(odcmClass));
                 retVal.Add(FetcherExpandMethod.ForFetcher(odcmClass));
                 retVal.Add(FetcherUpdateMethod.ForFetcher(odcmClass));
+                retVal.Add(FetcherUpdateLinkMethod.ForFetcher(odcmClass));
                 retVal.Add(FetcherDeleteMethod.ForFetcher(odcmClass));
+                retVal.Add(FetcherDeleteLinkMethod.ForFetcher(odcmClass));
+                retVal.Add(FetcherSetMethod.ForFetcher(odcmClass));
                 retVal.Add(FetcherSaveChangesAsyncMethod.ForFetcher(odcmClass));
             }
 

--- a/src/Writers/Vipr.Writer.CSharp.Lite/SourceCodeGenerator.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/SourceCodeGenerator.cs
@@ -1170,7 +1170,7 @@ namespace Vipr.Writer.CSharp.Lite
             _("set");
             using (_builder.IndentBraced)
             {
-                 _("{0} = value;", property.UpdatedName);
+                _("{0} = value;", property.UpdatedName);
             }
         }
 
@@ -1179,7 +1179,7 @@ namespace Vipr.Writer.CSharp.Lite
             _("get");
             using (_builder.IndentBraced)
             {
-               _("return {0};", property.UpdatedName);
+                _("return {0};", property.UpdatedName);
             }
         }
 

--- a/src/Writers/Vipr.Writer.CSharp.Lite/SourceCodeGenerator.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/SourceCodeGenerator.cs
@@ -450,12 +450,39 @@ namespace Vipr.Writer.CSharp.Lite
             }
         }
 
+        private void Write(FetcherUpdateLinkMethod method)
+        {
+            WriteSignature(method);
+            using (_builder.IndentBraced)
+            {
+                _("return base.UpdateLinkAsync(source, target, deferSaveChanges);");
+            }
+        }
+
         private void Write(FetcherDeleteMethod method)
         {
             WriteSignature(method);
             using (_builder.IndentBraced)
             {
                 _("return base.DeleteAsync(item, deferSaveChanges);");
+            }
+        }
+
+        private void Write(FetcherDeleteLinkMethod method)
+        {
+            WriteSignature(method);
+            using (_builder.IndentBraced)
+            {
+                _("return base.FetcherDeleteLinkAsync(source, deferSaveChanges);");
+            }
+        }
+
+        private void Write(FetcherSetMethod method)
+        {
+            WriteSignature(method);
+            using (_builder.IndentBraced)
+            {
+                _("return base.SetAsync(source, target, deferSaveChanges);");
             }
         }
 
@@ -1143,7 +1170,7 @@ namespace Vipr.Writer.CSharp.Lite
             _("set");
             using (_builder.IndentBraced)
             {
-                _("{0} = value;", property.UpdatedName);
+                 _("{0} = value;", property.UpdatedName);
             }
         }
 
@@ -1152,7 +1179,7 @@ namespace Vipr.Writer.CSharp.Lite
             _("get");
             using (_builder.IndentBraced)
             {
-                _("return {0};", property.UpdatedName);
+               _("return {0};", property.UpdatedName);
             }
         }
 

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Vipr.Writer.CSharp.Lite.csproj
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Vipr.Writer.CSharp.Lite.csproj
@@ -73,6 +73,7 @@
     <Compile Include="ExplicitlyImplementableMember.cs" />
     <Compile Include="Feature.cs" />
     <Compile Include="Features.cs" />
+    <Compile Include="FetcherDeleteLinkMethod.cs" />
     <Compile Include="FetcherDeleteMethod.cs" />
     <Compile Include="FetcherExecuteAsyncMethod.cs" />
     <Compile Include="DefaultConstructor.cs" />
@@ -85,7 +86,9 @@
     <Compile Include="FetcherNavigationProperty.cs" />
     <Compile Include="ConcreteUpcastMethod.cs" />
     <Compile Include="FetcherSaveChangesAsyncMethod.cs" />
+    <Compile Include="FetcherSetMethod.cs" />
     <Compile Include="FetcherUpcastMethod.cs" />
+    <Compile Include="FetcherUpdateLinkMethod.cs" />
     <Compile Include="FetcherUpdateMethod.cs" />
     <Compile Include="Fields.cs" />
     <Compile Include="GeneratedEdmModelCreateXmlReaderMethod.cs" />

--- a/test/CSharpLiteWriterUnitTests/CSharpLiteWriterUnitTests.csproj
+++ b/test/CSharpLiteWriterUnitTests/CSharpLiteWriterUnitTests.csproj
@@ -138,8 +138,11 @@
     <Compile Include="Given_an_Indenter.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Bound_Function_Base.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_DeleteAsync_Method.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_SaveChangesAsync_Method.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs" />
     <Compile Include="Given_an_OdcmClass_Service_Bound_Function_Collection.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Collection_Bound_Function_Collection.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Bound_Function_Collection.cs" />

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher.cs
@@ -90,5 +90,41 @@ namespace CSharpLiteWriterUnitTests
                 new System.Type[] { typeof(bool), typeof(Microsoft.OData.Client.SaveChangesOptions) },
                 "Because it allows saving changes made to entities.");
         }
+
+        [Fact]
+        public void The_Fetcher_class_implements_an_UpdateLinkAsync_method()
+        {
+            FetcherType.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "UpdateLinkAsync",
+                new System.Type[] { typeof(object), ConcreteInterface, typeof(bool) },
+                "Because it allows updating relationship between entities.");
+        }
+
+        [Fact]
+        public void The_Fetcher_class_implements_a_DeleteLinkAsync_method()
+        {
+            FetcherType.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "DeleteLinkAsync",
+                new System.Type[] { ConcreteInterface, typeof(bool) },
+                "Because it allows deleting relationship between entities.");
+        }
+
+        [Fact]
+        public void The_Fetcher_class_implements_an_SetAsync_method()
+        {
+            FetcherType.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "SetAsync",
+                new System.Type[] {typeof(object), ConcreteInterface, typeof(bool) },
+                "Because it allows creating new entities.");
+        }
     }
 }

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method.cs
@@ -1,0 +1,89 @@
+﻿
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Its.Recipes;
+using Microsoft.MockService;
+using Microsoft.MockService.Extensions.ODataV4;
+using Newtonsoft.Json.Linq;
+using Vipr.Core.CodeModel;
+using Xunit;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method : EntityTestBase
+    {
+        private MockService _mockedService;
+        private OdcmEntityClass _navPropertyClass;
+        private OdcmProperty _navProperty;
+        private System.Type _navPropertyFetcherType;
+
+        public Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method()
+        {
+            Init(odcmModel =>
+            {
+                // create a single-valued navigation property for 'Class' entity type.
+                _navPropertyClass = Any.OdcmEntityClass(Namespace);
+                odcmModel.AddType(_navPropertyClass);
+                _navProperty = Any.OdcmProperty(p =>
+                {
+                    p.Class = Class;
+                    p.Projection = new OdcmProjection()
+                    {
+                        Type = _navPropertyClass
+                    };
+                });
+                Class.Properties.Add(_navProperty);
+            });
+
+            _navPropertyFetcherType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name + "Fetcher");
+        }
+
+        /*
+         * DELETE request can be used to delete relationships/links between entities.
+         * In this test 'DeleteLinkAsync' is called to delete a link between an entitytype and its 
+         * single-valued navigation property.
+         * Example request
+         * DELETE http://services.odata.org/V4/TripPinServiceRW/People('russellwhyte')/Photo/$ref
+         * This request deletes the link between entity "People('russellwhyte')" and its single-valued navigation 
+         * property called 'Photo'.
+         * 
+         * Spec - http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398334
+         */
+        [Fact]
+        public void It_deletes_the_link_between_entity_and_singlevalued_navigation_property()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+
+            using (_mockedService = new MockService()
+                    .SetupPostEntity(TargetEntity, entityKeyValues)
+                    .OnDeleteLinkRequest(propertyPath)
+                        .RespondWithODataOk())
+            {
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+
+                fetcher.InvokeMethod<Task>("DeleteLinkAsync", new object[] { sourceInstance, System.Type.Missing }).Wait();
+            }
+        }
+
+        [Fact]
+        public void It_does_not_delete_a_link_when_delay_saving()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+
+            using (_mockedService = new MockService()
+                    .SetupPostEntity(TargetEntity, entityKeyValues))
+            {
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+
+                //delay save when deleting the link
+                fetcher.InvokeMethod<Task>("DeleteLinkAsync", new object[] { sourceInstance, true }).Wait();
+            }
+        }
+    }
+}

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs
@@ -1,0 +1,106 @@
+﻿
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Its.Recipes;
+using Microsoft.MockService;
+using Microsoft.MockService.Extensions.ODataV4;
+using Microsoft.OData.ProxyExtensions.Lite;
+using Newtonsoft.Json.Linq;
+using Vipr.Core.CodeModel;
+using Xunit;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method : EntityTestBase
+    {
+        private MockService _mockedService;
+        private OdcmEntityClass _navPropertyClass;
+        private OdcmProperty _navProperty;
+        private System.Type _navPropertyFetcherType;
+        private System.Type _navPropertyConcreteType;
+
+        public Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method()
+        {
+            Init(odcmModel =>
+            {
+                // create a single-valued navigation property for 'Class' entity type.
+                _navPropertyClass = Any.OdcmEntityClass(Namespace);
+                odcmModel.AddType(_navPropertyClass);
+                _navProperty = Any.OdcmProperty(p =>
+                {
+                    p.Class = Class;
+                    p.Projection = new OdcmProjection()
+                    {
+                        Type = _navPropertyClass
+                    };
+                });
+                Class.Properties.Add(_navProperty);
+            });
+
+            _navPropertyFetcherType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name + "Fetcher");
+            _navPropertyConcreteType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name);
+        }
+
+        /*
+         * PATCH request can be used push entity objects created on the client to the server.
+         * In this test 'SetAsync' is called to create a new entity on the server.
+         * Example request
+         * PATCH http://services.odata.org/V4/TripPinServiceRW/People('russellwhyte')/Photo
+         * Request Body 
+         * *Serliazed JSON object of the newly created 'Photo' entity*
+         * 
+         * This request creates a new 'Photo' for  entity "People('russellwhyte')" at its single-valued navigation 
+         * property called 'Photo'.
+         * 
+         * Spec - http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398330
+         */
+
+        [Fact]
+        public void It_creates_a_new_entity_for_singlevalued_navigation_property()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+            var entity2KeyValues = _navPropertyClass.GetSampleKeyArguments().ToArray();
+            var expectedJObject = new JObject();
+            var targetInstance = Activator.CreateInstance(_navPropertyConcreteType);
+
+            foreach (var keyProperty in entity2KeyValues)
+            {
+                var key = _navPropertyConcreteType.GetKeyProperties().Single(p => p.Name == keyProperty.Item1);
+                key.SetValue(targetInstance, keyProperty.Item2);
+                expectedJObject[keyProperty.Item1] = (string)keyProperty.Item2;
+            }
+
+            using (_mockedService = new MockService()
+                    .SetupPostEntity(TargetEntity, entityKeyValues)
+                    .OnPatchEntityRequest(propertyPath, expectedJObject)
+                    .RespondWithODataOk())
+            {
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+
+                fetcher.InvokeMethod<Task>("SetAsync", new object[] { sourceInstance, targetInstance, System.Type.Missing }).Wait();
+            }
+        }
+
+        [Fact]
+        public void It_does_not_create_a_new_entity_when_delay_saving()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+            var targetInstance = Activator.CreateInstance(_navPropertyConcreteType);
+
+            using (_mockedService = new MockService()
+                    .SetupPostEntity(TargetEntity, entityKeyValues))
+            {
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+
+                fetcher.InvokeMethod<Task>("SetAsync", new object[] { sourceInstance, targetInstance, true }).Wait();
+            }
+        }
+    }
+}

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs
@@ -44,7 +44,7 @@ namespace CSharpLiteWriterUnitTests
             
             using (_mockedService = new MockService()
                     .SetupPostEntity(TargetEntity, entityKeyValues)
-                    .OnInvokeMethodRequest("PATCH", expectedPath, null, jobject)
+                    .OnPatchEntityRequest(expectedPath, jobject)
                         .RespondWithODataOk())
             {
                 var context = _mockedService.GetDefaultContext(Model);

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs
@@ -1,0 +1,133 @@
+﻿
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Its.Recipes;
+using Microsoft.MockService;
+using Microsoft.MockService.Extensions.ODataV4;
+using Newtonsoft.Json.Linq;
+using Vipr.Core.CodeModel;
+using Xunit;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method : EntityTestBase
+    {
+        private MockService _mockedService;
+        private OdcmEntityClass _navPropertyClass;
+        private OdcmProperty _navProperty;
+        private System.Type _navPropertyFetcherType;
+        private System.Type _navPropertyConcreteType;
+        private EntityArtifacts _navPropertyEntity;
+
+        public Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method()
+        {
+            Init(odcmModel =>
+            {
+                // create a single-valued navigation property for 'Class' entity type.
+                _navPropertyClass = Any.OdcmEntityClass(Namespace);
+                odcmModel.AddType(_navPropertyClass);
+                _navProperty = Any.OdcmProperty(p =>
+                {
+                    p.Class = Class;
+                    p.Projection = new OdcmProjection()
+                    {
+                        Type = _navPropertyClass
+                    };
+                });
+                Class.Properties.Add(_navProperty);
+
+                var serviceClass = Model.EntityContainer;
+
+                var projection = new OdcmProjection() { Type = _navPropertyClass };
+
+                serviceClass.Properties.Add(new OdcmProperty(_navPropertyClass.Name) { Class = serviceClass, Projection = projection });
+
+                serviceClass.Properties.Add(new OdcmProperty(_navPropertyClass.Name + "s")
+                {
+                    Class = serviceClass,
+                    Projection = projection,
+                    IsCollection = true
+                });
+            });
+
+            _navPropertyFetcherType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name + "Fetcher");
+            _navPropertyConcreteType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name);
+
+            _navPropertyEntity = new EntityArtifacts()
+            {
+                Class = _navPropertyClass,
+                ConcreteType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name),
+                ConcreteInterface = Proxy.GetClass(_navPropertyClass.Namespace, "I" + _navPropertyClass.Name),
+                FetcherType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name + "Fetcher"),
+                FetcherInterface = Proxy.GetClass(_navPropertyClass.Namespace, "I" +_navPropertyClass.Name + "Fetcher"),
+                CollectionType = Proxy.GetClass(_navPropertyClass.Namespace, _navPropertyClass.Name + "Collection"),
+                CollectionInterface = Proxy.GetInterface(_navPropertyClass.Namespace, "I" + _navPropertyClass.Name + "Collection")
+            };
+        }
+
+        /*
+         * PUT request can be used to modify relationships/links between entities.
+         * In this test 'UpdateLinkAsync' is called to update a link between an entitytype and its 
+         * single-valued navigation property.
+         * Example request
+         * PUT http://services.odata.org/V4/TripPinServiceRW/People('russellwhyte')/Photo/$ref
+         * Request Body
+         * {"@odata.id":"http://services.odata.org/V4/TripPinServiceRW/Photos(2)"}
+         * 
+         * This request modifies the link between entity "People('russellwhyte')" and its single-valued navigation 
+         * property called 'Photo' to point to Photos(2).
+         * 
+         * Spec - http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398335
+         */
+
+        [Fact]
+        public void It_Updates_the_link_between_entity_and_singlevalued_navigation_property()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+            var entity2KeyValues = _navPropertyClass.GetSampleKeyArguments().ToArray();
+            var entity2Path = _navPropertyClass.GetDefaultEntityPath(entity2KeyValues);
+
+            using (_mockedService = new MockService())
+            {
+                var baseAddress = _mockedService.GetBaseAddress().TrimEnd('/');
+                var expectedJObject = new JObject();
+                expectedJObject["@odata.id"] = baseAddress + entity2Path;
+
+                _mockedService
+                    .SetupPostEntity(TargetEntity, entityKeyValues)
+                    .SetupPostEntity(_navPropertyEntity, entity2KeyValues)
+                    .OnPutUpdateLinkRequest(propertyPath, expectedJObject)
+                    .RespondWithODataOk();
+            
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+                var targetInstance = context.CreateConcrete(_navPropertyConcreteType);
+
+                fetcher.InvokeMethod<Task>("UpdateLinkAsync", new object[] { sourceInstance, targetInstance, System.Type.Missing }).Wait();
+            }
+        }
+
+        [Fact]
+        public void It_does_not_update_a_link_when_delay_saving()
+        {
+            var entityKeyValues = Class.GetSampleKeyArguments().ToArray();
+            var propertyPath = Class.GetDefaultEntityPath(entityKeyValues) + "/" + _navProperty.Name;
+            var entity2KeyValues = _navPropertyClass.GetSampleKeyArguments().ToArray();
+
+            using (_mockedService = new MockService()
+                    .SetupPostEntity(TargetEntity, entityKeyValues)
+                    .SetupPostEntity(_navPropertyEntity, entity2KeyValues))
+            {
+
+                var context = _mockedService.GetDefaultContext(Model);
+                var fetcher = context.CreateFetcher(_navPropertyFetcherType, propertyPath);
+                var sourceInstance = context.CreateConcrete(ConcreteType);
+                var targetInstance = context.CreateConcrete(_navPropertyConcreteType);
+
+                fetcher.InvokeMethod<Task>("UpdateLinkAsync", new object[] { sourceInstance, targetInstance, true }).Wait();
+            }
+        }
+    }
+}

--- a/test/Shared/MockService/Extensions/ODataV4/MockServiceExtensions.cs
+++ b/test/Shared/MockService/Extensions/ODataV4/MockServiceExtensions.cs
@@ -11,10 +11,22 @@ namespace Microsoft.MockService.Extensions.ODataV4
                 .OnRequest(c => c.Request.Method == "POST" && c.Request.Path.Value == entitySetPath);
         }
 
-        public static ResponseBuilder OnPatchEntityRequest(this MockService mockService, string entityPath)
+        public static ResponseBuilder OnPutUpdateLinkRequest(this MockService mockService, string entitySetPath, JObject expectedBody)
         {
             return mockService
-                .OnRequest(c => c.Request.Method == "PATCH" && c.Request.Path.Value == entityPath);
+                .OnRequest(c => c.Request.Method == "PUT" && 
+                    c.Request.Path.Value == entitySetPath + "/$ref" &&
+                    ((c.Request.Body.Length == 0 && expectedBody == null) ||
+                     (JToken.DeepEquals(expectedBody, c.Request.Body.ToJObject()))));
+        }
+
+        public static ResponseBuilder OnPatchEntityRequest(this MockService mockService, string entityPath, JObject expectedBody = null)
+        {
+            return mockService
+                .OnRequest(c => c.Request.Method == "PATCH" && 
+                    c.Request.Path.Value == entityPath &&
+                    (expectedBody == null ||
+                     (JToken.DeepEquals(expectedBody, c.Request.Body.ToJObject()))));
         }
 
         public static ResponseBuilder OnGetEntityRequest(this MockService mockService, string entitySetPath)
@@ -27,6 +39,12 @@ namespace Microsoft.MockService.Extensions.ODataV4
         {
             return mockService
                 .OnRequest(c => c.Request.Method == "DELETE" && c.Request.Path.Value == entityPath);
+        }
+
+        public static ResponseBuilder OnDeleteLinkRequest(this MockService mockService, string entityPath)
+        {
+            return mockService
+                .OnRequest(c => c.Request.Method == "DELETE" && c.Request.Path.Value == entityPath + "/$ref");
         }
 
         public static ResponseBuilder OnGetEntityWithExpandRequest(this MockService mockService, string entitySetPath,


### PR DESCRIPTION

DeleteLinkAsync
 - It deletes the link between an EntityType and its single-valued navigation property.

UpdateLinkAsync
 - It updates/modifies the link between an EntityType and its single-valued navigation property.

SetAsync
 - Its sets/creates a new entity for the navigation property of an entity type.

Note: The explicit interface navigation properties are not yet removed from the data/concrete classes. It will be done when all the appropriate methods for the collection fetchers.