### PR TITLE
Add new OdcmCapability - OdcmUpdateLinkCapability and OdcmDeleteLinkCapability to the OdcmModel

### DIFF
--- a/src/Core/Vipr.Core/CodeModel/OdcmProjection.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmProjection.cs
@@ -10,6 +10,6 @@ namespace Vipr.Core.CodeModel
     {
         public OdcmType Type { get; set; }
 
-        public IList<OdcmCapability> Capabilities { get; set; }
+        public IEnumerable<OdcmCapability> Capabilities { get; set; }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmProjection.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmProjection.cs
@@ -1,15 +1,85 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Vipr.Core.CodeModel.Vocabularies.Capabilities;
 
 namespace Vipr.Core.CodeModel
 {
-    public class OdcmProjection
+    public class OdcmProjection : IEquatable<OdcmProjection>
     {
         public OdcmType Type { get; set; }
 
         public IEnumerable<OdcmCapability> Capabilities { get; set; }
+
+        public bool SupportsUpdate()
+        {
+            var capability = GetCapability<OdcmUpdateCapability>();
+            return capability != null && capability.Updatable;
+        }
+
+        public bool SupportsUpdateLink()
+        {
+            var capability = GetCapability<OdcmUpdateLinkCapability>();
+            return capability != null && capability.Updatable;
+        }
+
+        public bool SupportsDelete()
+        {
+            var capability = GetCapability<OdcmDeleteCapability>();
+            return capability != null && capability.Deletable;
+        }
+
+        public bool SupportsDeleteLink()
+        {
+            var capability = GetCapability<OdcmDeleteLinkCapability>();
+            return capability != null && capability.Deletable;
+        }
+
+        public bool SupportsInsert()
+        {
+            var capability = GetCapability<OdcmInsertCapability>();
+            return capability != null && capability.Insertable;
+        }
+
+        public bool SupportsExpand()
+        {
+            var capability = GetCapability<OdcmExpandCapability>();
+            return capability != null && capability.Expandable;
+        }
+
+        public bool ContainsAllCapabilities(IEnumerable<OdcmCapability> capabilities)
+        {
+            return capabilities.Count() == this.Capabilities.Count() &&
+                   this.Capabilities.All(capabilities.Contains);
+        }
+
+        public bool Equals(OdcmProjection otherProjection)
+        {
+            return this.Type == otherProjection.Type && this.ContainsAllCapabilities(otherProjection.Capabilities);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashcode = 17;
+            if (Type != null)
+            {
+                hashcode = hashcode * 31 + Type.GetHashCode();
+            }
+
+            foreach (var capability in Capabilities)
+            {
+                hashcode = hashcode * 31 + capability.GetHashCode();
+            }
+
+            return hashcode;
+        }
+
+        public T GetCapability<T>() where T : OdcmCapability
+        {
+            return Capabilities.SingleOrDefault(c => c.GetType() == typeof(T)) as T;
+        }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmType.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmType.cs
@@ -45,7 +45,7 @@ namespace Vipr.Core.CodeModel
         /// </summary>
         /// <param name="capabilities">A list of capabilities</param>
         /// <returns>A Projection of this OdcmType with the given capabilities</returns>
-        public OdcmProjection GetProjection(IList<OdcmCapability> capabilities)
+        public OdcmProjection GetProjection(IEnumerable<OdcmCapability> capabilities)
         {
             //Find if we already have a 'Projection' for the given capabilities.
             OdcmProjection projection =

--- a/src/Core/Vipr.Core/CodeModel/OdcmType.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmType.cs
@@ -21,11 +21,19 @@ namespace Vipr.Core.CodeModel
             get { return _projections.AsEnumerable(); }
         }
 
+        public OdcmProjection DefaultProjection { get; private set; }
+
         protected OdcmType(string name, OdcmNamespace @namespace)
             : base(name)
         {
             Namespace = @namespace;
             _projections = new List<OdcmProjection>();
+            DefaultProjection = new OdcmProjection()
+            {
+                Type = this,
+                Capabilities = OdcmCapability.DefaultOdcmCapabilities
+            };
+            _projections.Add(DefaultProjection);
         }
 
         public string FullName

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmBooleanCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmBooleanCapability.cs
@@ -21,5 +21,12 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
 
             return other.GetType() == this.GetType() && other.Value == this.Value;
         }
+
+        public override int GetHashCode()
+        {
+            int hash = this.GetType().GetHashCode();
+            hash = hash * 31 + this.Value.GetHashCode();
+            return hash;
+        }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmCapability.cs
@@ -12,7 +12,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
     {
         public abstract string TermName { get; }
 
+        public abstract string ShortName { get; }
+
         public abstract bool Equals(OdcmCapability otherCapability);
+
+        public abstract int GetHashCode();
 
         private static List<OdcmCapability> GetAllOdcmCapabilities()
         {

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.DeleteRestrictions"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Del"; }
+        }
+
         /// <summary>
         /// Entities can be deleted
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteLinkCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteLinkCapability.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
+{
+    public class OdcmDeleteLinkCapability : OdcmBooleanCapability
+    {
+        public override string TermName
+        {
+            get { return "Org.OData.Capabilities.V1.DeleteRestrictions/NonDeletableNavigationProperties"; }
+        }
+
+        /// <summary>
+        /// Reference/link to an entity can be deleted
+        /// </summary>
+        public bool Deletable
+        {
+            get { return Value; }
+        }
+
+        public OdcmDeleteLinkCapability()
+        {
+            Value = true;
+        }
+    }
+}

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteLinkCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmDeleteLinkCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.DeleteRestrictions/NonDeletableNavigationProperties"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Dlk"; }
+        }
+
         /// <summary>
         /// Reference/link to an entity can be deleted
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmExpandCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmExpandCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.ExpandRestrictions"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Exp"; }
+        }
+
         /// <summary>
         /// $expand is supported
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmInsertCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmInsertCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.InsertRestrictions"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Ins"; }
+        }
+
         /// <summary>
         /// Entities can be inserted
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.UpdateRestrictions"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Upd"; }
+        }
+
         /// <summary>
         /// Entities can be updated
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateLinkCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateLinkCapability.cs
@@ -10,6 +10,11 @@ namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
             get { return "Org.OData.Capabilities.V1.UpdateRestrictions/NonUpdatableNavigationProperties"; }
         }
 
+        public override string ShortName
+        {
+            get { return "Ulk"; }
+        }
+
         /// <summary>
         /// Reference/link to an entity can be updated
         /// </summary>

--- a/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateLinkCapability.cs
+++ b/src/Core/Vipr.Core/CodeModel/Vocabularies/Capabilities/OdcmUpdateLinkCapability.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Vipr.Core.CodeModel.Vocabularies.Capabilities
+{
+    public class OdcmUpdateLinkCapability : OdcmBooleanCapability
+    {
+        public override string TermName
+        {
+            get { return "Org.OData.Capabilities.V1.UpdateRestrictions/NonUpdatableNavigationProperties"; }
+        }
+
+        /// <summary>
+        /// Reference/link to an entity can be updated
+        /// </summary>
+        public bool Updatable
+        {
+            get { return Value; }
+        }
+
+        public OdcmUpdateLinkCapability()
+        {
+            Value = true;
+        }
+    }
+}

--- a/src/Core/Vipr.Core/OdcmExtensions.cs
+++ b/src/Core/Vipr.Core/OdcmExtensions.cs
@@ -42,12 +42,6 @@ namespace Vipr.Core
             return false;
         }
 
-        public static bool ContainsAllCapabilities(this OdcmProjection odcmProjection, IEnumerable<OdcmCapability> capabilities)
-        {
-            return capabilities.Count() == odcmProjection.Capabilities.Count() &&
-                   odcmProjection.Capabilities.All(capabilities.Contains);
-        }
-
         public static IEnumerable<OdcmClass> NestedDerivedTypes(this OdcmClass odcmClass)
         {
             var graph = new Queue<OdcmClass>();
@@ -73,6 +67,23 @@ namespace Vipr.Core
         {
             return odcmMethod.Parameters
                 .Where(p => p.CallingConvention == OdcmCallingConvention.InHttpMessageBody);
+        }
+
+        public static string GetProjectionShortForm(this OdcmProjection projection)
+        {
+            var result = string.Empty;
+
+            var capabilities = projection.Capabilities.OrderBy(c => c.ShortName);
+
+            foreach (var capability in capabilities)
+            {
+                if (capability is OdcmBooleanCapability && ((OdcmBooleanCapability)capability).Value)
+                {
+                    result = result + "_" + capability.ShortName;
+                }
+            }
+
+            return result.Trim('_');
         }
     }
 }

--- a/src/Core/Vipr.Core/OdcmExtensions.cs
+++ b/src/Core/Vipr.Core/OdcmExtensions.cs
@@ -42,9 +42,9 @@ namespace Vipr.Core
             return false;
         }
 
-        public static bool ContainsAllCapabilities(this OdcmProjection odcmProjection, IList<OdcmCapability> capabilities)
+        public static bool ContainsAllCapabilities(this OdcmProjection odcmProjection, IEnumerable<OdcmCapability> capabilities)
         {
-            return capabilities.Count == odcmProjection.Capabilities.Count &&
+            return capabilities.Count() == odcmProjection.Capabilities.Count() &&
                    odcmProjection.Capabilities.All(capabilities.Contains);
         }
 

--- a/src/Core/Vipr.Core/Vipr.Core.csproj
+++ b/src/Core/Vipr.Core/Vipr.Core.csproj
@@ -54,9 +54,11 @@
     <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmBooleanCapability.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmCapability.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmDeleteCapability.cs" />
+    <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmDeleteLinkCapability.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmExpandCapability.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmInsertCapability.cs" />
-    <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmUpdateCapability.cs" />    
+    <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmUpdateCapability.cs" />
+    <Compile Include="CodeModel\Vocabularies\Capabilities\OdcmUpdateLinkCapability.cs" />
     <Compile Include="RelativeFile.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\DeleteRestrictionsType.cs" />
     <Compile Include="CodeModel\Vocabularies\Capabilities\ExpandRestrictionsType.cs" />

--- a/src/Core/Vipr/Vipr.csproj
+++ b/src/Core/Vipr/Vipr.csproj
@@ -67,6 +67,10 @@
       <Project>{6d8d8008-0a34-490f-8b38-21d9c8bf25c0}</Project>
       <Name>Vipr.Reader.OData.v4</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Writers\Vipr.Writer.CSharp.Lite\Vipr.Writer.CSharp.Lite.csproj">
+      <Project>{d3505caf-50b1-4353-bebf-b61568e54b37}</Project>
+      <Name>Vipr.Writer.CSharp.Lite</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Writers\Vipr.Writer.CSharp\Vipr.Writer.CSharp.csproj">
       <Project>{ea55efcf-3127-4e85-9a37-a645c06ffcc1}</Project>
       <Name>Vipr.Writer.CSharp</Name>

--- a/src/ProxyExtensions/Microsoft.OData.ProxyExtensions.Lite/QueryableSet.cs
+++ b/src/ProxyExtensions/Microsoft.OData.ProxyExtensions.Lite/QueryableSet.cs
@@ -81,6 +81,16 @@ namespace Microsoft.OData.ProxyExtensions.Lite
             return Context.SaveChangesAsync(saveChangesOption);
         }
 
+        protected TFetcher GetFetcherById<TInstance, TFetcher>(Expression<Func<TInstance, bool>> whereExpression)
+            where TFetcher : RestShallowObjectFetcher, new()
+            where TInstance : TSource
+        {
+            var path = GetPath(whereExpression);
+            var fetcher = new TFetcher();
+            fetcher.Initialize(Context, path);
+            return fetcher;
+        }
+
         protected Uri GetUrl()
         {
             return new Uri(Context.BaseUri.ToString().TrimEnd('/') + "/" + Path);

--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -15,6 +15,13 @@ namespace Vipr.Reader.OData.v4.Capabilities
 {
     public abstract class CapabilityAnnotationParser
     {
+        protected PropertyCapabilitiesCache _propertyCapabilitiesCache;
+
+        protected CapabilityAnnotationParser(PropertyCapabilitiesCache propertyCapabilitiesCache)
+        {
+            _propertyCapabilitiesCache = propertyCapabilitiesCache;
+        }
+
         private static IEdmModel _capabilitiesModel;
 
         public static IEdmModel CapabilitiesModel
@@ -37,7 +44,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
             }
         }
 
-        public abstract void ParseCapabilityAnnotationForEntitySet(OdcmProperty odcmEntitySet, IEdmValueAnnotation annotation,
-            ODataCapabilitiesReader.PropertyCapabilitiesCache propertyCache);
+        public abstract void ParseCapabilityAnnotationForEntitySet(OdcmProperty odcmEntitySet,
+            IEdmValueAnnotation annotation);
     }
 }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Class.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Class.cs
@@ -45,8 +45,8 @@ namespace Vipr.Writer.CSharp.Lite
                 Constructors = global::Vipr.Writer.CSharp.Lite.Constructors.ForFetcher(odcmClass),
                 Fields = global::Vipr.Writer.CSharp.Lite.Fields.ForFetcher(odcmClass),
                 Identifier = NamesService.GetFetcherTypeName(odcmClass),
-                Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForFetcher(odcmClass),
-                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForFetcher(odcmClass),
+                Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForFetcherClass(odcmClass),
+                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForFetcherClass(odcmClass),
                 Properties = global::Vipr.Writer.CSharp.Lite.Properties.ForFetcher(odcmClass),
             };
         }
@@ -97,9 +97,9 @@ namespace Vipr.Writer.CSharp.Lite
                 BaseClass = new Type(NamesService.GetExtensionTypeName("QueryableSet"),
                                      new Type(NamesService.GetConcreteInterfaceName(odcmClass))),
                 Constructors = global::Vipr.Writer.CSharp.Lite.Constructors.ForCollection(odcmClass),
-                Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForCollection(odcmClass),
+                Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForCollectionClass(odcmClass),
                 Identifier = NamesService.GetCollectionTypeName(odcmClass),
-                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForCollection(odcmClass),
+                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForCollectionClass(odcmClass),
                 Indexers = global::Vipr.Writer.CSharp.Lite.Indexers.ForCollection(odcmClass)
             };
         }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/CollectionGetByIdIndexer.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/CollectionGetByIdIndexer.cs
@@ -12,16 +12,24 @@ namespace Vipr.Writer.CSharp.Lite
     {
         public Dictionary<Parameter, OdcmProperty> ParameterToPropertyMap { get; private set; }
 
-        public CollectionGetByIdIndexer(OdcmEntityClass odcmClass)
+        public CollectionGetByIdIndexer(OdcmEntityClass odcmClass, OdcmProjection projection)
         {
             ParameterToPropertyMap = odcmClass.Key.ToDictionary(Parameter.FromProperty, p => p);
 
             Parameters = global::Vipr.Writer.CSharp.Lite.Parameters.GetKeyParameters(odcmClass);
-            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass));
+            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass, projection));
             OdcmClass = odcmClass;
 
             IsSettable = false;
             IsGettable = true;
+        }
+
+        public static CollectionGetByIdIndexer ForCollectionClass(OdcmEntityClass odcmClass, OdcmProjection projection)
+        {
+            return new CollectionGetByIdIndexer(odcmClass, projection)
+            {
+                DefiningInterface = NamesService.GetCollectionInterfaceName(odcmClass, projection)
+            };
         }
 
         public OdcmClass OdcmClass { get; private set; }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/CollectionGetByIdMethod.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/CollectionGetByIdMethod.cs
@@ -1,17 +1,33 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Vipr.Core.CodeModel;
 
 namespace Vipr.Writer.CSharp.Lite
 {
     public class CollectionGetByIdMethod : Method
     {
-        public CollectionGetByIdMethod(OdcmClass odcmClass)
+        public OdcmClass OdcmClass { get; private set; }
+
+        public Dictionary<Parameter, OdcmProperty> ParameterToPropertyMap { get; private set; }
+
+        public CollectionGetByIdMethod(OdcmClass odcmClass, OdcmProjection projection = null)
         {
             Name = "GetById";
+            ParameterToPropertyMap = ((OdcmEntityClass)odcmClass).Key.ToDictionary(Parameter.FromProperty, p => p);
             Parameters = global::Vipr.Writer.CSharp.Lite.Parameters.GetKeyParameters(odcmClass);
-            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass));
+            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass, projection));
+            OdcmClass = odcmClass;
+        }
+
+        public static CollectionGetByIdMethod ForCollectionClass(OdcmClass odcmClass, OdcmProjection projection = null)
+        {
+            return new CollectionGetByIdMethod(odcmClass, projection)
+            {
+                DefiningInterface = NamesService.GetCollectionInterfaceName(odcmClass, projection)
+            };
         }
     }
 }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherExpandMethod.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherExpandMethod.cs
@@ -10,7 +10,7 @@ namespace Vipr.Writer.CSharp.Lite
     {
         public OdcmClass OdcmClass { get; private set; }
 
-        private FetcherExpandMethod(OdcmClass odcmClass)
+        private FetcherExpandMethod(OdcmClass odcmClass, OdcmProjection projection = null)
         {
             Visibility = Visibility.Public;
             Name = "Expand";
@@ -21,20 +21,20 @@ namespace Vipr.Writer.CSharp.Lite
                     new Type(new Identifier("System", "Func"), new Type(NamesService.GetConcreteInterfaceName(odcmClass)),
                         new Type(new Identifier(null, "TTarget")))), "navigationPropertyAccessor"),
             };
-            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass));
+            ReturnType = new Type(NamesService.GetFetcherInterfaceName(odcmClass, projection));
             OdcmClass = odcmClass;
         }
 
-        public static FetcherExpandMethod ForFetcher(OdcmClass odcmClass)
+        public static FetcherExpandMethod ForFetcherInterface(OdcmClass odcmClass, OdcmProjection projection)
         {
-            return new FetcherExpandMethod(odcmClass);
+            return new FetcherExpandMethod(odcmClass, projection);
         }
 
-        public static FetcherExpandMethod ForConcrete(OdcmClass odcmClass)
+        public static FetcherExpandMethod ForFetcherClass(OdcmClass odcmClass, OdcmProjection projection)
         {
-            return new FetcherExpandMethod(odcmClass)
+            return new FetcherExpandMethod(odcmClass, projection)
             {
-                DefiningInterface = NamesService.GetFetcherInterfaceName(odcmClass)
+                DefiningInterface = NamesService.GetFetcherInterfaceName(odcmClass, projection)
             };
         }
     }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherNavigationCollectionProperty.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherNavigationCollectionProperty.cs
@@ -12,10 +12,10 @@ namespace Vipr.Writer.CSharp.Lite
         protected FetcherNavigationCollectionProperty(OdcmProperty odcmProperty)
             : base(odcmProperty)
         {
-            CollectionType = new Type(NamesService.GetCollectionTypeName((OdcmClass)odcmProperty.Type));
+            CollectionType = new Type(NamesService.GetCollectionTypeName((OdcmClass)odcmProperty.Projection.Type));
             FieldName = NamesService.GetFetcherCollectionFieldName(odcmProperty);
-            InstanceType = NamesService.GetConcreteTypeName(odcmProperty.Type);
-            Type = new Type(NamesService.GetCollectionInterfaceName((OdcmClass)odcmProperty.Type));
+            InstanceType = NamesService.GetConcreteTypeName(odcmProperty.Projection.Type);
+            Type = new Type(NamesService.GetCollectionInterfaceName((OdcmClass)odcmProperty.Projection.Type, odcmProperty.Projection));
         }
 
         public new static FetcherNavigationProperty ForConcrete(OdcmProperty odcmProperty)

--- a/src/Writers/Vipr.Writer.CSharp.Lite/FetcherNavigationProperty.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/FetcherNavigationProperty.cs
@@ -12,9 +12,9 @@ namespace Vipr.Writer.CSharp.Lite
         protected FetcherNavigationProperty(OdcmProperty odcmProperty) : base(odcmProperty)
         {
             FieldName = NamesService.GetFetcherFieldName(odcmProperty);
-            InstanceType = NamesService.GetFetcherTypeName(odcmProperty.Type);
+            InstanceType = NamesService.GetFetcherTypeName(odcmProperty.Projection.Type);
             PrivateSet = true;
-            Type = new Type(NamesService.GetFetcherInterfaceName(odcmProperty.Type));
+            Type = new Type(NamesService.GetFetcherInterfaceName(odcmProperty.Projection.Type, odcmProperty.Projection));
         }
 
         public static FetcherNavigationProperty ForConcrete(OdcmProperty odcmProperty)

--- a/src/Writers/Vipr.Writer.CSharp.Lite/ImplementedInterfaces.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/ImplementedInterfaces.cs
@@ -6,9 +6,16 @@ namespace Vipr.Writer.CSharp.Lite
 {
     public class ImplementedInterfaces
     {
-        public static IEnumerable<Type> ForFetcher(OdcmClass odcmClass)
+        public static IEnumerable<Type> ForFetcherClass(OdcmClass odcmClass)
         {
-            return new List<Type> { new Type(NamesService.GetFetcherInterfaceName(odcmClass)) };
+            var retVal = new List<Type>();
+
+            foreach (var projection in odcmClass.Projections)
+            {
+                retVal.Add(new Type(NamesService.GetFetcherInterfaceName(odcmClass, projection)));
+            }
+
+            return retVal;
         }
 
         public static IEnumerable<Type> ForConcrete(OdcmClass odcmClass)
@@ -21,9 +28,16 @@ namespace Vipr.Writer.CSharp.Lite
             return retVal;
         }
 
-        public static IEnumerable<Type> ForCollection(OdcmClass odcmClass)
+        public static IEnumerable<Type> ForCollectionClass(OdcmClass odcmClass)
         {
-            return new List<Type> { new Type(NamesService.GetCollectionInterfaceName(odcmClass)) };
+            var retVal = new List<Type>();
+
+            foreach (var projection in odcmClass.Projections)
+            {
+                retVal.Add(new Type(NamesService.GetCollectionInterfaceName(odcmClass, projection)));
+            }
+
+            return retVal;
         }
 
         public static IEnumerable<Type> ForEntityContainer(OdcmClass odcmContainer)

--- a/src/Writers/Vipr.Writer.CSharp.Lite/IndexerSignature.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/IndexerSignature.cs
@@ -12,11 +12,11 @@ namespace Vipr.Writer.CSharp.Lite
         public bool IsSettable { get; protected set; }
         public bool IsGettable { get; protected set; }
 
-        public static IEnumerable<IndexerSignature> ForCollectionInterface(OdcmEntityClass odcmClass)
+        public static IEnumerable<IndexerSignature> ForCollectionInterface(OdcmEntityClass odcmClass, OdcmProjection projection)
         {
             return new IndexerSignature[]
             {
-                new CollectionGetByIdIndexer(odcmClass)
+                new CollectionGetByIdIndexer(odcmClass, projection)
             };
         }
     }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Indexers.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Indexers.cs
@@ -11,10 +11,13 @@ namespace Vipr.Writer.CSharp.Lite
     {
         public static IEnumerable<Indexer> ForCollection(OdcmEntityClass odcmClass)
         {
-            return new Indexer[]
+            var retVal = new List<Indexer>();
+            foreach (var projection in odcmClass.Projections)
             {
-                new CollectionGetByIdIndexer(odcmClass)
-            };
+                retVal.Add(CollectionGetByIdIndexer.ForCollectionClass(odcmClass, projection));
+            }
+
+            return retVal;
         }
 
         public static IEnumerable<Indexer> Empty { get { return Enumerable.Empty<Indexer>(); } }

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Interface.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Interface.cs
@@ -30,9 +30,10 @@ namespace Vipr.Writer.CSharp.Lite
             Properties = new List<InterfaceProperty>();
         }
 
-        public static Interface ForConcrete(OdcmClass odcmClass)
+        public static IEnumerable<Interface> ForConcrete(OdcmClass odcmClass)
         {
-            return new Interface
+
+            var @interface =  new Interface
             {
                 Attributes = global::Vipr.Writer.CSharp.Lite.Attributes.ForConcreteInterface,
                 Identifier = NamesService.GetConcreteInterfaceName(odcmClass),
@@ -41,32 +42,50 @@ namespace Vipr.Writer.CSharp.Lite
                 Properties = global::Vipr.Writer.CSharp.Lite.Properties.ForConcreteInterface(odcmClass),
                 Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForConcreteInterface(odcmClass)
             };
+
+            return new List<Interface>() { @interface };
         }
 
-        public static Interface ForFetcher(OdcmClass odcmClass)
+        public static IEnumerable<Interface> ForFetcher(OdcmClass odcmClass)
         {
-            return new Interface
+            var interfaces = new List<Interface>();
+            foreach (var projection in odcmClass.Projections)
             {
-                Attributes = global::Vipr.Writer.CSharp.Lite.Attributes.ForFetcherInterface,
-                Identifier = NamesService.GetFetcherInterfaceName(odcmClass),
-                Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForFetcherInterface(odcmClass),
-                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForFetcherInterface(odcmClass),
-                Namespace = NamesService.GetNamespaceName(odcmClass.Namespace),
-                Properties = global::Vipr.Writer.CSharp.Lite.Properties.ForFetcherInterface(odcmClass)
-            };
+                var @interface = new Interface
+                {
+                    Attributes = global::Vipr.Writer.CSharp.Lite.Attributes.ForFetcherInterface,
+                    Identifier = NamesService.GetFetcherInterfaceName(odcmClass, projection),
+                    Interfaces = global::Vipr.Writer.CSharp.Lite.ImplementedInterfaces.ForFetcherInterface(odcmClass),
+                    Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForFetcherInterface(odcmClass, projection),
+                    Namespace = NamesService.GetNamespaceName(odcmClass.Namespace),
+                    Properties = global::Vipr.Writer.CSharp.Lite.Properties.ForFetcherInterface(odcmClass)
+                };
+
+                interfaces.Add(@interface);
+            }
+
+            return interfaces;
         }
 
-        public static Interface ForCollection(OdcmEntityClass odcmClass)
+        public static IEnumerable<Interface> ForCollection(OdcmEntityClass odcmClass)
         {
-            return new Interface
+            var interfaces = new List<Interface>();
+            foreach (var projection in odcmClass.Projections)
             {
-                Attributes = global::Vipr.Writer.CSharp.Lite.Attributes.ForCollectionInterface,
-                Identifier = NamesService.GetCollectionInterfaceName(odcmClass),
-                Namespace = NamesService.GetNamespaceName(odcmClass.Namespace),
-                Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForCollectionInterface(odcmClass),
-                Indexers = IndexerSignature.ForCollectionInterface(odcmClass),
-                Interfaces = new[] { new Type(NamesService.GetExtensionTypeName("IReadOnlyQueryableSetBase"), new Type(NamesService.GetConcreteInterfaceName(odcmClass))) }
-            };
+                var @interface = new Interface
+                {
+                    Attributes = global::Vipr.Writer.CSharp.Lite.Attributes.ForCollectionInterface,
+                    Identifier = NamesService.GetCollectionInterfaceName(odcmClass, projection),
+                    Namespace = NamesService.GetNamespaceName(odcmClass.Namespace),
+                    Methods = global::Vipr.Writer.CSharp.Lite.Methods.ForCollectionInterface(odcmClass, projection),
+                    Indexers = IndexerSignature.ForCollectionInterface(odcmClass, projection),
+                    Interfaces = new[] { new Type(NamesService.GetExtensionTypeName("IReadOnlyQueryableSetBase"), new Type(NamesService.GetConcreteInterfaceName(odcmClass))) }
+                };
+
+                interfaces.Add(@interface);
+            }
+
+            return interfaces;
         }
 
         public static Interface ForEntityContainer(OdcmClass odcmContainer)

--- a/src/Writers/Vipr.Writer.CSharp.Lite/Interfaces.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/Interfaces.cs
@@ -13,12 +13,9 @@ namespace Vipr.Writer.CSharp.Lite
 
         internal static IEnumerable<Interface> ForOdcmClassEntity(OdcmEntityClass odcmClass)
         {
-            return new[]
-            {
-                Interface.ForConcrete(odcmClass),
-                Interface.ForFetcher(odcmClass),
-                Interface.ForCollection(odcmClass),
-            };
+            return Interface.ForConcrete(odcmClass)
+                .Concat(Interface.ForFetcher(odcmClass))
+                .Concat(Interface.ForCollection(odcmClass));
         }
 
         internal static IEnumerable<Interface> ForOdcmClassService(OdcmClass odcmClass)

--- a/src/Writers/Vipr.Writer.CSharp.Lite/NamesService.cs
+++ b/src/Writers/Vipr.Writer.CSharp.Lite/NamesService.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Vipr.Core;
 using Vipr.Core.CodeModel;
 
 namespace Vipr.Writer.CSharp.Lite
 {
-    internal static class NamesService
+    public static class NamesService
     {
         private const string DataServiceKey = "global::Microsoft.OData.Client.Key";
         private const string EntitySet = "global::Microsoft.OData.Client.EntitySet";
@@ -133,15 +134,30 @@ namespace Vipr.Writer.CSharp.Lite
             return new Identifier(resolvedName.Namespace, resolvedName.Name + "Fetcher");
         }
 
-        public static Identifier GetFetcherInterfaceName(OdcmType odcmType)
+        public static Identifier GetFetcherInterfaceName(OdcmType odcmType, OdcmProjection projection = null)
         {
+            if (projection == null)
+            {
+                projection = odcmType.DefaultProjection;
+            }
+
             var fetcherTypeName = GetFetcherTypeName(odcmType);
-            return GetConcreteInterfaceName(fetcherTypeName);
+            return new Identifier(fetcherTypeName.Namespace,
+                "I" + fetcherTypeName.Name + GetProjectionSuffix(projection));
         }
 
-        private static Identifier GetConcreteInterfaceName(Identifier typeName)
+        private static string GetProjectionSuffix(OdcmProjection projection)
         {
-            return new Identifier(typeName.Namespace, "I" + typeName.Name);
+            string suffix = String.Empty;
+            if (projection != null)
+            {
+                suffix = projection.GetProjectionShortForm();
+                if(!string.IsNullOrEmpty(suffix))
+                {
+                    suffix = "_" + suffix;
+                }
+            }
+            return suffix;
         }
 
         internal static string GetFetcherCollectionFieldName(OdcmProperty odcmProperty)
@@ -154,18 +170,23 @@ namespace Vipr.Writer.CSharp.Lite
             return GetPropertyFieldName(odcmProperty) + "Fetcher";
         }
 
-        public static Identifier GetCollectionTypeName(OdcmClass odcmClass)
+        public static Identifier GetCollectionTypeName(OdcmType odcmType)
         {
-            Identifier instanceTypeName = GetConcreteTypeName(odcmClass);
+            Identifier instanceTypeName = GetConcreteTypeName(odcmType);
 
             return new Identifier(instanceTypeName.Namespace, instanceTypeName.Name + "Collection");
         }
 
-        public static Identifier GetCollectionInterfaceName(OdcmClass odcmClass)
+        public static Identifier GetCollectionInterfaceName(OdcmType odcmType, OdcmProjection projection = null)
         {
-            Identifier collectionTypeName = GetCollectionTypeName(odcmClass);
+            if (projection == null)
+            {
+                projection = odcmType.DefaultProjection;
+            }
+            Identifier collectionTypeName = GetCollectionTypeName(odcmType);
 
-            return new Identifier(collectionTypeName.Namespace, "I" + collectionTypeName.Name);
+            return new Identifier(collectionTypeName.Namespace,
+                "I" + collectionTypeName.Name + GetProjectionSuffix(projection));
         }
 
         public static string GetConcreteFieldName(OdcmProperty property)

--- a/test/CSharpLiteWriterUnitTests/AnnotationUnitTests/Given_an_OdcmObject_with_Description.cs
+++ b/test/CSharpLiteWriterUnitTests/AnnotationUnitTests/Given_an_OdcmObject_with_Description.cs
@@ -282,7 +282,8 @@ namespace CSharpLiteWriterUnitTests
             property.Class = @class;
             _model.AddType(@class);
             _model.AddType(property.Type);
-            string propertyName = string.Format("P:{0}.I{1}Fetcher.{2}", @class.Namespace.Name, @class.Name, property.Name);
+            var fetcherInterface = NamesService.GetFetcherInterfaceName(@class);
+            string propertyName = string.Format("P:{0}.{1}.{2}", @class.Namespace.Name, fetcherInterface.Name, property.Name);
 
             var xmlContent = GetProxyXmlDocumentContent(_model);
             var summary = GetSummary(xmlContent, propertyName);
@@ -365,7 +366,8 @@ namespace CSharpLiteWriterUnitTests
             _model.AddType(@class);
 
             var xmlContent = GetProxyXmlDocumentContent(_model);
-            string methodName = string.Format("M:{0}.I{1}Fetcher.{2}Async", @class.Namespace.Name, @class.Name, method.Name);
+            var fetcherInterface = NamesService.GetFetcherInterfaceName(@class);
+            string methodName = string.Format("M:{0}.{1}.{2}Async", @class.Namespace.Name, fetcherInterface.Name, method.Name);
             var summary = GetSummary(xmlContent, methodName);
             summary
                 .Should()

--- a/test/CSharpLiteWriterUnitTests/CSharpLiteWriterUnitTests.csproj
+++ b/test/CSharpLiteWriterUnitTests/CSharpLiteWriterUnitTests.csproj
@@ -146,6 +146,9 @@
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_with_multiple_OdcmProjections.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_Navigation_Property_with_OdcmProjection.cs" />
+    <Compile Include="Given_an_OdcmClass_Entity_with_OdcmProjection.cs" />
     <Compile Include="Given_an_OdcmClass_Service_Bound_Function_Collection.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Collection_Bound_Function_Collection.cs" />
     <Compile Include="Given_an_OdcmClass_Entity_Bound_Function_Collection.cs" />

--- a/test/CSharpLiteWriterUnitTests/EntityTestBase.cs
+++ b/test/CSharpLiteWriterUnitTests/EntityTestBase.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 using Moq;
 using Vipr.Core;
 using Vipr.Core.CodeModel;
+using Vipr.Writer.CSharp.Lite;
+using Type = System.Type;
 
 namespace CSharpLiteWriterUnitTests
 {
@@ -57,11 +59,13 @@ namespace CSharpLiteWriterUnitTests
 
             FetcherType = Proxy.GetClass(Class.Namespace, Class.Name + "Fetcher");
 
-            FetcherInterface = Proxy.GetInterface(Class.Namespace, "I" + Class.Name + "Fetcher");
+            var identifier = NamesService.GetFetcherInterfaceName(Class);
+            FetcherInterface = Proxy.GetInterface(Class.Namespace, identifier.Name);
 
             CollectionType = Proxy.GetClass(Class.Namespace, Class.Name + "Collection");
 
-            CollectionInterface = Proxy.GetInterface(Class.Namespace, "I" + Class.Name + "Collection");
+            identifier = NamesService.GetCollectionInterfaceName(Class);
+            CollectionInterface = Proxy.GetInterface(Class.Namespace, identifier.Name);
 
             EntityContainerType = Proxy.GetClass(Model.EntityContainer.Namespace, Model.EntityContainer.Name);
 

--- a/test/CSharpLiteWriterUnitTests/Given_a_ConfigurationProvider.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_a_ConfigurationProvider.cs
@@ -344,7 +344,8 @@ namespace CSharpLiteWriterUnitTests
 
                     if (cl.Kind == OdcmClassKind.Entity)
                     {
-                        proxy.GetInterface(ns.Name, "I" + cl.Name + "Fetcher")
+                        var fetcherInterface = NamesService.GetFetcherInterfaceName(cl);
+                        proxy.GetInterface(ns.Name, fetcherInterface.Name)
                             .Properties()
                             .Select(p => p.Name.Substring(p.Name.LastIndexOf('.') + 1))
                             .Should().Contain(cl.NavigationProperties().Select(GetPascalCaseName).Where(n => n[0] != '_'), because: "Because the fetcher's navigation properties should be capitalized.")
@@ -483,10 +484,7 @@ namespace CSharpLiteWriterUnitTests
                             {
                                 Class = property.Class,
                                 ReadOnly = property.ReadOnly,
-                                Projection = new OdcmProjection()
-                                {
-                                    Type = property.Type
-                                }
+                                Projection = property.Projection
                             };
 
                         cl.Properties.Add(lowerCaseProperty);

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_AddLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_AddLinkAsync_Method.cs
@@ -24,17 +24,14 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection()
-                    {
-                        Type = NavTargetClass
-                    };
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = true;
                 });
                 Class.Properties.Add(NavigationProperty);
 
                 var serviceClass = Model.EntityContainer;
 
-                var projection = new OdcmProjection() { Type = NavTargetClass };
+                var projection = NavTargetClass.DefaultProjection;
 
                 serviceClass.Properties.Add(new OdcmProperty(NavTargetClass.Name) { Class = serviceClass, Projection = projection });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_GetById_Indexer.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_GetById_Indexer.cs
@@ -29,7 +29,9 @@ namespace CSharpLiteWriterUnitTests
                     .GetDefaultContext(Model)
                     .CreateCollection(CollectionType, ConcreteType, Class.GetDefaultEntitySetPath());
 
-                var fetcher = collection.GetIndexerValue<RestShallowObjectFetcher>(keyValues.Select(k => k.Item2).ToArray());
+                var fetcher =
+                    collection.GetIndexerValue<RestShallowObjectFetcher>(keyValues.Select(k => k.Item2).ToArray(),
+                        @interface: CollectionInterface.Name);
 
                 var task = fetcher.ExecuteAsync();
                 task.Wait();

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_GetById_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_GetById_Method.cs
@@ -32,7 +32,7 @@ namespace CSharpLiteWriterUnitTests
                 var collection = context.CreateCollection(CollectionType, ConcreteType, Class.GetDefaultEntitySetPath());
 
                 var fetcher = collection.InvokeMethod<RestShallowObjectFetcher>("GetById",
-                    keyValues.Select(k => k.Item2).ToArray());
+                    keyValues.Select(k => k.Item2).ToArray(), @interface: CollectionInterface.Name);
 
                 var task = fetcher.ExecuteAsync();
                 task.Wait();

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_RemoveLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_RemoveLinkAsync_Method.cs
@@ -24,17 +24,14 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection()
-                    {
-                        Type = NavTargetClass
-                    };
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = true;
                 });
                 Class.Properties.Add(NavigationProperty);
 
                 var serviceClass = Model.EntityContainer;
 
-                var projection = new OdcmProjection() { Type = NavTargetClass };
+                var projection = NavTargetClass.DefaultProjection;
 
                 serviceClass.Properties.Add(new OdcmProperty(NavTargetClass.Name) { Class = serviceClass, Projection = projection });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_UpdateAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Collection_UpdateAsync_Method.cs
@@ -22,10 +22,8 @@ namespace CSharpLiteWriterUnitTests
                 _structuralInstanceProperty = Any.PrimitiveOdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection
-                    {
-                        Type = new OdcmPrimitiveType("String", OdcmNamespace.Edm)
-                    };
+                    var type = new OdcmPrimitiveType("String", OdcmNamespace.Edm);
+                    p.Projection = type.DefaultProjection;
                 });
                 Class.Properties.Add(_structuralInstanceProperty);
             });

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Derived.cs
@@ -20,8 +20,6 @@ namespace CSharpLiteWriterUnitTests
         private Type _baseConcreteInterface;
         private Type _baseFetcherType;
         private Type _baseFetcherInterface;
-        private Type _baseCollectionType;
-        private Type _baseCollectionInterface;
         private string _toDerivedMethodName;
 
         
@@ -46,11 +44,8 @@ namespace CSharpLiteWriterUnitTests
 
             _baseFetcherType = Proxy.GetClass(_baseClass.Namespace, _baseClass.Name + "Fetcher");
 
-            _baseFetcherInterface = Proxy.GetInterface(_baseClass.Namespace, "I" + _baseClass.Name + "Fetcher");
-
-            _baseCollectionType = Proxy.GetClass(_baseClass.Namespace, _baseClass.Name + "Collection");
-
-            _baseCollectionInterface = Proxy.GetInterface(_baseClass.Namespace, "I" + _baseClass.Name + "Collection");
+            var identifier = NamesService.GetFetcherInterfaceName(_baseClass);
+            _baseFetcherInterface = Proxy.GetInterface(_baseClass.Namespace, identifier.Name);
 
             _toDerivedMethodName = "To" + ConcreteType.Name;
         }

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher.cs
@@ -20,7 +20,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_Collection_class_is_Internal()
+        public void The_Fetcher_class_is_Internal()
         {
             FetcherType.IsInternal()
                 .Should().BeTrue("Because entity types are accessed by the Concrete, Fetcher, " +
@@ -36,7 +36,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_fetcher_proxy_class_implements_the_Fetcher_Interface()
+        public void The_fetcher_proxy_class_implements_the_default_Fetcher_Interface()
         {
             FetcherType.Should().Implement(
                 FetcherInterface,

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_DeleteLinkAsync_Method.cs
@@ -24,10 +24,7 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection()
-                    {
-                        Type = NavTargetClass
-                    };
+                    p.Projection = NavTargetClass.DefaultProjection;
                 });
                 Class.Properties.Add(NavigationProperty);
             });

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_Expand_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_Expand_Method.cs
@@ -34,7 +34,10 @@ namespace CSharpLiteWriterUnitTests
                     .GetDefaultContext(Model)
                     .CreateFetcher(FetcherType, Class.GetDefaultEntitySetName());
 
-                fetcher.InvokeMethod<RestShallowObjectFetcher>("Expand", new []{lambda}, new []{ConcreteInterface}).InvokeMethod<Task>("ExecuteAsync").GetPropertyValue<EntityBase>("Result");
+                fetcher.InvokeMethod<RestShallowObjectFetcher>("Expand", new[] {lambda}, new[] {ConcreteInterface},
+                    FetcherInterface.Name)
+                    .InvokeMethod<Task>("ExecuteAsync")
+                    .GetPropertyValue<EntityBase>("Result");
             }
         }
 
@@ -58,8 +61,8 @@ namespace CSharpLiteWriterUnitTests
                     .CreateFetcher(FetcherType, Class.GetDefaultEntitySetName());
 
                 fetcher
-                    .InvokeMethod<RestShallowObjectFetcher>("Expand", new[] { lambda1 }, new[] { ConcreteInterface })
-                    .InvokeMethod<RestShallowObjectFetcher>("Expand", new[] { lambda2 }, new[] { ConcreteInterface })
+                    .InvokeMethod<RestShallowObjectFetcher>("Expand", new[] { lambda1 }, new[] { ConcreteInterface }, FetcherInterface.Name)
+                    .InvokeMethod<RestShallowObjectFetcher>("Expand", new[] { lambda2 }, new[] { ConcreteInterface }, FetcherInterface.Name)
                     .InvokeMethod<Task>("ExecuteAsync").GetPropertyValue<EntityBase>("Result");
             }
         }

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_SetAsync_Method.cs
@@ -26,10 +26,7 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection()
-                    {
-                        Type = NavTargetClass
-                    };
+                    p.Projection = NavTargetClass.DefaultProjection;
                 });
                 Class.Properties.Add(NavigationProperty);
             });

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateAsync_Method.cs
@@ -22,10 +22,8 @@ namespace CSharpLiteWriterUnitTests
                 _structuralInstanceProperty = Any.PrimitiveOdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection
-                    {
-                        Type = new OdcmPrimitiveType("String", OdcmNamespace.Edm)
-                    };
+                    var type = new OdcmPrimitiveType("String", OdcmNamespace.Edm);
+                    p.Projection = type.DefaultProjection;
                 });
                 Class.Properties.Add(_structuralInstanceProperty);
             });

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Fetcher_UpdateLinkAsync_Method.cs
@@ -24,16 +24,13 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = Class;
-                    p.Projection = new OdcmProjection()
-                    {
-                        Type = NavTargetClass
-                    };
+                    p.Projection = NavTargetClass.DefaultProjection;
                 });
                 Class.Properties.Add(NavigationProperty);
 
                 var serviceClass = Model.EntityContainer;
 
-                var projection = new OdcmProjection() { Type = NavTargetClass };
+                var projection = NavTargetClass.DefaultProjection;
 
                 serviceClass.Properties.Add(new OdcmProperty(NavTargetClass.Name) { Class = serviceClass, Projection = projection });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Collection.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Collection.cs
@@ -31,8 +31,8 @@ namespace CSharpLiteWriterUnitTests
                 var @class = @namespace.Classes.First();
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
-                    p.Class = @class;
-                    p.Projection.Type = NavTargetClass;
+                    p.Class = @class;                    
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = true;
                 });
 
@@ -51,7 +51,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_Fetcher_interface_exposes_a_readonly_CollectionInterface_property()
+        public void The_Fetcher_interface_exposes_a_readonly_CollectionInterface_property_with_default_projection()
         {
             FetcherInterface.Should().HaveProperty(
                 CSharpAccessModifiers.Public,
@@ -61,7 +61,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_Fetcher_class_exposes_a_readonly_CollectionInterface_property()
+        public void The_Fetcher_class_exposes_a_readonly_CollectionInterface_property_with_default_projection()
         {
             FetcherType.Should().HaveProperty(
                 CSharpAccessModifiers.Public,
@@ -186,7 +186,8 @@ public class Given_an_OdcmClass_Entity_Uninitialized : NavigationPropertyTestBas
             NavigationProperty = Any.OdcmProperty(p =>
             {
                 p.Class = @class;
-                p.Projection.Type = NavTargetClass;
+                //p.Projection.Type = NavTargetClass;
+                p.Projection = NavTargetClass.DefaultProjection;
                 p.IsCollection = true;
             });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Instance.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_Instance.cs
@@ -19,7 +19,6 @@ namespace CSharpLiteWriterUnitTests
 
         public Given_an_OdcmClass_EntityNavigation_Property_Instance()
         {
-            NavigationProperty = Any.OdcmProperty(p => p.Projection.Type = Class);
 
             base.Init(m =>
             {
@@ -31,7 +30,7 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = @class;
-                    p.Projection.Type = NavTargetClass;
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = false;
                 });
 
@@ -72,7 +71,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_Fetcher_interface_exposes_a_readonly_FetcherInterface_property()
+        public void The_Fetcher_interface_exposes_a_readonly_FetcherInterface_property_with_default_projection()
         {
             FetcherInterface.Should().HaveProperty(
                 CSharpAccessModifiers.Public,
@@ -82,7 +81,7 @@ namespace CSharpLiteWriterUnitTests
         }
 
         [Fact]
-        public void The_Fetcher_class_exposes_a_readonly_Fetcher_Interface_property()
+        public void The_Fetcher_class_exposes_a_readonly_Fetcher_Interface_property_with_default_projection()
         {
             FetcherType.Should().HaveProperty(
                 CSharpAccessModifiers.Public,

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_with_OdcmProjection.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_Navigation_Property_with_OdcmProjection.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using FluentAssertions;
+using Microsoft.Its.Recipes;
+using System.Linq;
+using Microsoft.MockService;
+using Microsoft.MockService.Extensions.ODataV4;
+using Microsoft.OData.ProxyExtensions.Lite;
+using Xunit;
+using System.Threading.Tasks;
+using Vipr.Writer.CSharp.Lite;
+using Vipr.Core.CodeModel;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_Navigation_Property_with_OdcmProjection : NavigationPropertyTestBase
+    {
+        private System.Type m_NavTargetFetcherInterface;
+        private System.Type m_NavTargetCollectionInterface;
+        private OdcmProjection m_NavTargetProjection;
+        
+
+        private void Init(bool isCollection)
+        {
+            base.Init(m =>
+            {
+                var @namespace = m.Namespaces[0];
+                NavTargetClass = Any.OdcmEntityClass(@namespace);
+                @namespace.Types.Add(NavTargetClass);
+
+                m_NavTargetProjection = Any.OdcmProjection(NavTargetClass);
+                if (!NavTargetClass.Projections.Contains(m_NavTargetProjection))
+                {
+                    NavTargetClass.Projections.AsList().Add(m_NavTargetProjection);
+                }
+
+                var @class = @namespace.Classes.First();                
+                NavigationProperty = Any.OdcmProperty(p =>
+                {
+                    p.Class = @class;
+                    p.Projection = m_NavTargetProjection;
+                    p.IsCollection = isCollection;
+                });
+
+                m.Namespaces[0].Classes.First().Properties.Add(NavigationProperty);
+            });
+
+             var identifier = NamesService.GetFetcherInterfaceName(NavTargetClass, m_NavTargetProjection);
+             m_NavTargetFetcherInterface = Proxy.GetInterface(NavTargetClass.Namespace, identifier.Name);
+
+             identifier = NamesService.GetCollectionInterfaceName(NavTargetClass, m_NavTargetProjection);
+             m_NavTargetCollectionInterface = Proxy.GetInterface(NavTargetClass.Namespace, identifier.Name);             
+        }
+
+        [Fact]
+        public void When_single_valued_nav_prop_Then_Fetcher_interface_exposes_a_readonly_property_with_projected_FetcherInterface()
+        {
+            Init(false);
+
+            FetcherInterface.Should().HaveProperty(
+                CSharpAccessModifiers.Public,
+                null,
+                m_NavTargetFetcherInterface,
+                NavigationProperty.Name);
+        }
+
+        [Fact]
+        public void When_single_valued_nav_prop_Then_Fetcher_class_exposes_a_readonly_property_with_projected_FetcherInterface()
+        {
+            Init(false);
+
+            FetcherType.Should().HaveProperty(
+                CSharpAccessModifiers.Public,
+                null,
+                m_NavTargetFetcherInterface,
+                NavigationProperty.Name);
+        }
+
+        [Fact]
+        public void When_collection_valued_nav_prop_Then_Fetcher_interface_exposes_a_readonly_property_with_projected_CollectionInterface()
+        {
+            Init(true);
+
+            FetcherInterface.Should().HaveProperty(
+                CSharpAccessModifiers.Public,
+                null,
+                m_NavTargetCollectionInterface,
+                NavigationProperty.Name);
+        }
+
+        [Fact]
+        public void When_collection_valued_nav_prop_Then_Fetcher_class_exposes_a_readonly_property_with_projected_CollectionInterface()
+        {
+            Init(true);
+
+            FetcherType.Should().HaveProperty(
+                CSharpAccessModifiers.Public,
+                null,
+                m_NavTargetCollectionInterface,
+                NavigationProperty.Name);
+        }
+    }
+}

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_with_OdcmProjection.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_with_OdcmProjection.cs
@@ -1,0 +1,476 @@
+﻿using Microsoft.Its.Recipes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vipr.Core.CodeModel;
+using Vipr.Core.CodeModel.Vocabularies.Capabilities;
+using Vipr.Writer.CSharp.Lite;
+using Xunit;
+using Type = System.Type;
+using FluentAssertions;
+using System.Linq.Expressions;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_with_OdcmProjection : EntityTestBase
+    {
+        private Type m_FetcherInterface;
+        private Type m_CollectionInterface;
+        private OdcmClass m_TargetClass;
+
+        private void Init(OdcmProjection projection)
+        {            
+            base.Init(
+                m =>
+                {
+                    m_TargetClass = m.Namespaces[0].Classes.First();                    
+                    m_TargetClass.Properties.Add(Any.PrimitiveOdcmProperty(p => p.Class = Class));
+                    
+                    projection.Type = m_TargetClass;
+                    if (!m_TargetClass.Projections.Contains(projection))
+                    {
+                        m_TargetClass.Projections.AsList().Add(projection);
+                    }
+                });
+
+
+            var identifier = NamesService.GetFetcherInterfaceName(m_TargetClass, projection);
+            m_FetcherInterface = Proxy.GetInterface(m_TargetClass.Namespace, identifier.Name);
+
+            identifier = NamesService.GetCollectionInterfaceName(m_TargetClass, projection);
+            m_CollectionInterface = Proxy.GetInterface(m_TargetClass.Namespace, identifier.Name);
+        }
+
+        [Fact]
+        public void The_Fetcher_Interface_for_the_projection_has_only_supported_capabilities_encoded_in_its_name()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            Init(projection);
+
+            var expectedFetcherInterfaceName = "I" + m_TargetClass.Name + "Fetcher" + GetProjectionEncoding(projection);
+            m_FetcherInterface.Name.Should().Be(expectedFetcherInterfaceName);
+        }
+
+        [Fact]
+        public void The_Collection_Interface_for_the_projection_has_only_supported_capabilities_encoded_in_its_name()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            Init(projection);
+
+            var expectedCollectionInterfaceName = "I" + m_TargetClass.Name + "Collection" + GetProjectionEncoding(projection);
+            m_CollectionInterface.Name.Should().Be(expectedCollectionInterfaceName);
+        }
+
+        [Fact]        
+        public void When_projection_supports_Expand_then_fetcher_interface_exposes_Expand_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var expandCapability = projection.GetCapability<OdcmExpandCapability>();
+            expandCapability.Value = true;
+
+            Init(projection);
+
+            var expandMethod = m_FetcherInterface.GetMethod("Expand");
+
+            expandMethod.Should().NotBeNull("Because entity has Expand Capability");
+
+            expandMethod.IsPublic.Should().BeTrue();
+
+            expandMethod.GetGenericArguments().Count()
+                .Should().Be(1);
+
+            var genericArgType = expandMethod.GetGenericArguments()[0];
+
+            var expectedParamType =
+                typeof(Expression<>).MakeGenericType(typeof(Func<,>).MakeGenericType(ConcreteInterface, genericArgType));
+
+            expandMethod.GetParameters().Count()
+                .Should().Be(1);
+
+            expandMethod.GetParameters()[0].ParameterType
+                .Should().Be(expectedParamType);
+
+            expandMethod.ReturnType
+                .Should().Be(m_FetcherInterface);
+
+            m_FetcherInterface.Name.Should().Contain(expandCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Expand_then_fetcher_interface_does_not_expose_Expand_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var expandCapability = projection.GetCapability<OdcmExpandCapability>();
+            expandCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod("Expand", "Because entity does not have Expand Capability");
+            m_FetcherInterface.Name.Should().NotContain(expandCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Delete_then_fetcher_interface_exposes_DeleteAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteCapability = projection.GetCapability<OdcmDeleteCapability>();
+            deleteCapability.Value = true;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                typeof(Task),
+                "DeleteAsync",
+                new Type[] { ConcreteInterface, typeof(bool) },
+                "Because entity has Delete Capability");
+
+            m_FetcherInterface.Name.Should().Contain(deleteCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Delete_then_fetcher_interface_does_not_expose_DeleteAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteCapability = projection.GetCapability<OdcmDeleteCapability>();
+            deleteCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod(                
+                "DeleteAsync", "Because entity does not have Delete Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(deleteCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_DeleteLink_then_fetcher_interface_exposes_DeleteLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteLinkCapability = projection.GetCapability<OdcmDeleteLinkCapability>();
+            deleteLinkCapability.Value = true;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                typeof(Task),
+                "DeleteLinkAsync",
+                new Type[] { ConcreteInterface, typeof(bool) },
+                "Because entity has DeleteLink Capability");
+
+            m_FetcherInterface.Name.Should().Contain(deleteLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_DeleteLink_then_fetcher_interface_does_not_expose_DeleteLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteLinkCapability = projection.GetCapability<OdcmDeleteLinkCapability>();
+            deleteLinkCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod(
+                "DeleteLinkAsync", "Because entity does not have DeleteLink Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(deleteLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Update_then_fetcher_interface_exposes_UpdateAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = true;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                typeof(Task),
+                "UpdateAsync",
+                new Type[] { ConcreteInterface, typeof(bool) },
+                "Because entity has Update Capability");
+
+            m_FetcherInterface.Name.Should().Contain(updateCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Update_then_fetcher_interface_exposes_SetAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = true;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                typeof(Task),
+                "SetAsync",
+                new System.Type[] { typeof(object), ConcreteInterface, typeof(bool) },
+                "Because entity has Update Capability");
+
+            m_FetcherInterface.Name.Should().Contain(updateCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Update_then_fetcher_interface_does_not_expose_UpdateAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod(
+                "UpdateAsync", "Because entity does not have Update Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(updateCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Update_then_fetcher_interface_does_not_expose_SetAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod(
+                "SetAsync", "Because entity does not have Update Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(updateCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_UpdateLink_then_fetcher_interface_exposes_UpdateLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateLinkCapability = projection.GetCapability<OdcmUpdateLinkCapability>();
+            updateLinkCapability.Value = true;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                typeof(Task),
+                "UpdateLinkAsync",
+                new System.Type[] { typeof(object), ConcreteInterface, typeof(bool) },
+                "Because entity has UpdateLink Capability");
+
+            m_FetcherInterface.Name.Should().Contain(updateLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_UpdateLink_then_fetcher_interface_does_not_expose_UpdateLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateLinkCapability = projection.GetCapability<OdcmUpdateLinkCapability>();
+            updateLinkCapability.Value = false;
+
+            Init(projection);
+
+            m_FetcherInterface.Should().NotHaveMethod(
+                "UpdateLinkAsync", "Because entity does not have UpdateLink Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(updateLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Delete_then_collection_interface_exposes_DeleteAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteCapability = projection.GetCapability<OdcmDeleteCapability>();
+            deleteCapability.Value = true;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "DeleteAsync",
+                new System.Type[] { ConcreteInterface, typeof(bool) },
+                "Because entity has Delete Capability");
+
+            m_FetcherInterface.Name.Should().Contain(deleteCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Delete_then_collection_interface_does_not_expose_DeleteAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteCapability = projection.GetCapability<OdcmDeleteCapability>();
+            deleteCapability.Value = false;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().NotHaveMethod(
+                "DeleteAsync", "Because entity does not have Delete Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(deleteCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Update_then_collection_interface_exposes_UpdateAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = true;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "UpdateAsync",
+                new System.Type[] { ConcreteInterface, typeof(bool) },
+                "Because entity has Update Capability");
+
+            m_FetcherInterface.Name.Should().Contain(updateCapability.ShortName);
+
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Update_then_collection_interface_does_not_expose_UpdateAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateCapability = projection.GetCapability<OdcmUpdateCapability>();
+            updateCapability.Value = false;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().NotHaveMethod(
+                "UpdateAsync", "Because entity does not have Update Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(updateCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_Insert_then_collection_interface_exposes_AddAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var insertCapability = projection.GetCapability<OdcmInsertCapability>();
+            insertCapability.Value = true;
+
+            Init(projection);
+
+            m_CollectionInterface.Should()
+                .HaveMethod(
+                    CSharpAccessModifiers.Public,
+                    typeof(Task),
+                    "Add" + m_TargetClass.Name + "Async",
+                    new[] { ConcreteInterface, typeof(bool) },
+                    "Because entity has Insert Capability");
+
+            m_FetcherInterface.Name.Should().Contain(insertCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_Insert_then_collection_interface_does_not_expose_AddAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var insertCapability = projection.GetCapability<OdcmInsertCapability>();
+            insertCapability.Value = false;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().NotHaveMethod(
+                "Add" + m_TargetClass.Name + "Async", "Because entity does not have Insert Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(insertCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_UpdateLink_then_collection_interface_exposes_AddLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateLinkCapability = projection.GetCapability<OdcmUpdateLinkCapability>();
+            updateLinkCapability.Value = true;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "AddLinkAsync",
+                new System.Type[] { typeof(object), ConcreteInterface, typeof(bool) },
+                "Because entity has UpdateLink Capability");
+
+            m_FetcherInterface.Name.Should().Contain(updateLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_UpdateLink_then_collection_interface_does_not_expose_AddLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var updateLinkCapability = projection.GetCapability<OdcmUpdateLinkCapability>();
+            updateLinkCapability.Value = false;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().NotHaveMethod(
+                "AddLinkAsync", "Because entity does not have UpdateLink Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(updateLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_supports_DeleteLink_then_collection_interface_exposes_RemoveLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteLinkCapability = projection.GetCapability<OdcmDeleteLinkCapability>();
+            deleteLinkCapability.Value = true;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().HaveMethod(
+                CSharpAccessModifiers.Public,
+                false,
+                typeof(Task),
+                "RemoveLinkAsync",
+                new System.Type[] { typeof(object), ConcreteInterface, typeof(bool) },
+                "Because entity has DeleteLink Capability");
+
+            m_FetcherInterface.Name.Should().Contain(deleteLinkCapability.ShortName);
+        }
+
+        [Fact]
+        public void When_projection_does_not_support_DeleteLink_then_collection_interface_does_not_expose_RemoveLinkAsync_Method()
+        {
+            var projection = Any.OdcmProjection(m_TargetClass);
+            var deleteLinkCapability = projection.GetCapability<OdcmDeleteLinkCapability>();
+            deleteLinkCapability.Value = false;
+
+            Init(projection);
+
+            m_CollectionInterface.Should().NotHaveMethod(
+                "RemoveLinkAsync", "Because entity does not have DeleteLink Capability");
+
+            m_FetcherInterface.Name.Should().NotContain(deleteLinkCapability.ShortName);
+        }
+
+        private string GetProjectionEncoding(OdcmProjection projection)
+        {
+            var capabilities = projection.Capabilities.Where(c => ((OdcmBooleanCapability)c).Value).OrderBy(c => c.ShortName);
+            var capabilityEncodings = capabilities.Select(c => c.ShortName);
+            var suffix = string.Join("_", capabilityEncodings);
+
+            if (!string.IsNullOrEmpty(suffix))
+            {
+                suffix = "_" + suffix;
+            }
+
+            return suffix;
+        }
+        
+    }
+
+}

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_with_multiple_OdcmProjections.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Entity_with_multiple_OdcmProjections.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using FluentAssertions;
+using Microsoft.Its.Recipes;
+using Microsoft.OData.ProxyExtensions.Lite;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Vipr.Core.CodeModel;
+using Vipr.Writer.CSharp.Lite;
+using Xunit;
+using Type = System.Type;
+
+namespace CSharpLiteWriterUnitTests
+{
+    public class Given_an_OdcmClass_Entity_with_multiple_OdcmProjections : EntityTestBase
+    {        
+        private Dictionary<OdcmProjection, Tuple<Type, Type>> m_projectionFetcherCollectionMap =
+            new Dictionary<OdcmProjection, Tuple<Type, Type>>();
+        
+        public Given_an_OdcmClass_Entity_with_multiple_OdcmProjections()
+        {
+            IEnumerable<OdcmProjection> projections = null;
+            OdcmClass targetClass = null;
+            base.Init(
+                m =>
+                {
+                    targetClass = m.Namespaces[0].Classes.First();
+                    targetClass.Properties.Add(Any.PrimitiveOdcmProperty(p => p.Class = Class));
+                    projections = Any.OdcmProjections(targetClass).Distinct();
+                    foreach (var projection in projections)
+                    {
+                        if (!targetClass.Projections.Contains(projection))
+                        {
+                            targetClass.Projections.AsList().Add(projection);
+                        }
+                    }
+                });            
+
+            foreach (var projection in projections)
+            {
+                var identifier = NamesService.GetFetcherInterfaceName(targetClass, projection);
+                var fetcher = Proxy.GetInterface(targetClass.Namespace, identifier.Name);
+
+                identifier = NamesService.GetCollectionInterfaceName(targetClass, projection);
+                var collection = Proxy.GetInterface(targetClass.Namespace, identifier.Name);
+
+                var fetcherCollectionTuple = new Tuple<Type, Type>(fetcher, collection);
+                m_projectionFetcherCollectionMap.Add(projection, fetcherCollectionTuple);
+            }
+        }
+
+        [Fact]
+        public void The_fetcher_proxy_class_implements_multiple_fetcher_interfaces()
+        {
+            foreach (var projectionFetcherPair in m_projectionFetcherCollectionMap)
+            {
+                var fetcherInterface = projectionFetcherPair.Value.Item1;
+                FetcherType
+                    .Should()
+                    .Implement(fetcherInterface,
+                        "Because the implementation is internal and only accessible via the interface.");
+            }
+        }
+
+        [Fact]
+        public void The_collection_proxy_class_implements_multiple_collection_interfaces()
+        {
+            foreach (var projectionCollectionPair in m_projectionFetcherCollectionMap)
+            {
+                var collectionInterface = projectionCollectionPair.Value.Item2;
+                CollectionType
+                    .Should()
+                    .Implement(collectionInterface,
+                        "Because the implementation is internal and only accessible via the interface.");
+            }
+        }
+
+        [Fact]
+        public void The_fetcher_proxy_class_explicitly_implements_multiple_fetcher_interface_Expand_methods()
+        {
+            foreach (var projectionFetcherPair in m_projectionFetcherCollectionMap)
+            {
+                if (!projectionFetcherPair.Key.SupportsExpand())
+                {
+                    continue;
+                }
+
+                var fetcherInterface = projectionFetcherPair.Value.Item1;
+
+                var expandMethod =
+                    FetcherType.GetInterfaceMap(fetcherInterface).TargetMethods.Single(m => m.Name.EndsWith("Expand"));
+
+                expandMethod.Should().NotBeNull("Because it allows expanding");                
+
+                expandMethod.GetGenericArguments().Count()
+                    .Should().Be(1);
+
+                var genericArgType = expandMethod.GetGenericArguments()[0];
+
+                var expectedParamType =
+                    typeof(Expression<>).MakeGenericType(typeof(Func<,>).MakeGenericType(ConcreteInterface, genericArgType));
+
+                expandMethod.GetParameters().Count()
+                    .Should().Be(1);
+
+                expandMethod.GetParameters()[0].ParameterType
+                    .Should().Be(expectedParamType);
+
+                expandMethod.ReturnType
+                    .Should().Be(fetcherInterface);
+            }
+        }
+
+        [Fact]
+        public void The_collection_proxy_class_explicitly_implements_multiple_collection_interface_GetById_methods()
+        {
+            foreach (var projectionCollectionPair in m_projectionFetcherCollectionMap)
+            {
+                var fetcherInterface = projectionCollectionPair.Value.Item1;
+                var collectionInterface = projectionCollectionPair.Value.Item2;
+                CollectionType.Should().HaveExplicitMethod(
+                    collectionInterface, 
+                    "GetById", 
+                    fetcherInterface, 
+                    GetKeyPropertyTypes());
+            }
+        }
+
+        [Fact]
+        public void The_collection_proxy_class_explicitly_implements_multiple_collection_interface_GetById_indexers()
+        {
+            foreach (var projectionCollectionPair in m_projectionFetcherCollectionMap)
+            {
+                var fetcherInterface = projectionCollectionPair.Value.Item1;
+                var collectionInterface = projectionCollectionPair.Value.Item2;
+                CollectionType.Should().HaveExplicitMethod(
+                    collectionInterface,
+                    "get_Item",
+                    fetcherInterface,
+                    GetKeyPropertyTypes());
+            }
+        }        
+
+        private Type[] GetKeyPropertyTypes()
+        {
+            return Class.Key
+                .Select(p => p.Type)
+                .Select(t => Proxy.GetClass(t.Namespace, t.Name))
+                .ToArray();
+        }
+        
+    }
+}

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Navigation_Property_Collection.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Navigation_Property_Collection.cs
@@ -30,7 +30,7 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = OdcmContainer;
-                    p.Projection.Type = NavTargetClass;
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = true;
                 });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Navigation_Property_Instance.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Navigation_Property_Instance.cs
@@ -25,7 +25,7 @@ namespace CSharpLiteWriterUnitTests
                 NavigationProperty = Any.OdcmProperty(p =>
                 {
                     p.Class = OdcmContainer;
-                    p.Projection.Type = NavTargetClass;
+                    p.Projection = NavTargetClass.DefaultProjection;
                     p.IsCollection = false;
                 });
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Property_forced_to_pascal_case.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmClass_Service_Property_forced_to_pascal_case.cs
@@ -7,6 +7,7 @@ using Microsoft.Its.Recipes;
 using Moq;
 using Vipr.Core;
 using Vipr.Core.CodeModel;
+using Vipr.Writer.CSharp.Lite;
 using Xunit;
 
 namespace CSharpLiteWriterUnitTests
@@ -37,11 +38,15 @@ namespace CSharpLiteWriterUnitTests
         public void The_EntityContainer_class_has_the_renamed_property()
         {
             bool isCollection = _property.IsCollection;
+            var propertyType = _property.Projection.Type;
+            var identifier = isCollection
+                ? NamesService.GetCollectionInterfaceName(propertyType)
+                : NamesService.GetFetcherInterfaceName(propertyType);
 
             EntityContainerType.Should().HaveProperty(
                 CSharpAccessModifiers.Public, 
                 isCollection ? (CSharpAccessModifiers?)null : CSharpAccessModifiers.Private,
-                Proxy.GetInterface(_property.Type.Namespace, "I" + _property.Type.Name + (isCollection ? "Collection" : "Fetcher")),
+                Proxy.GetInterface(_property.Type.Namespace, identifier.Name),
                 GetPascalCaseName(_property));
         }
 

--- a/test/CSharpLiteWriterUnitTests/Given_an_OdcmNamespace.cs
+++ b/test/CSharpLiteWriterUnitTests/Given_an_OdcmNamespace.cs
@@ -69,10 +69,7 @@ namespace CSharpLiteWriterUnitTests
             @class.Properties.Add(new OdcmProperty(Any.CSharpIdentifier())
             {
                 Class = @class,
-                Projection = new OdcmProjection()
-                {
-                    Type = @class
-                }
+                Projection = @class.DefaultProjection
             });
 
             _model.AddType(@class);

--- a/test/CSharpLiteWriterUnitTests/NavigationPropertyTestBase.cs
+++ b/test/CSharpLiteWriterUnitTests/NavigationPropertyTestBase.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Vipr.Core.CodeModel;
+using Vipr.Writer.CSharp.Lite;
+using Type = System.Type;
 
 namespace CSharpLiteWriterUnitTests
 {
@@ -32,13 +34,13 @@ namespace CSharpLiteWriterUnitTests
 
             NavTargetFetcherType = Proxy.GetClass(NavTargetClass.Namespace, NavTargetClass.Name + "Fetcher");
 
-            NavTargetFetcherInterface = Proxy.GetInterface(NavTargetClass.Namespace,
-                "I" + NavTargetClass.Name + "Fetcher");
+            var identifier = NamesService.GetFetcherInterfaceName(NavTargetClass);
+            NavTargetFetcherInterface = Proxy.GetInterface(NavTargetClass.Namespace, identifier.Name);
 
             NavTargetCollectionType = Proxy.GetClass(NavTargetClass.Namespace, NavTargetClass.Name + "Collection");
 
-            NavTargetCollectionInterface = Proxy.GetInterface(NavTargetClass.Namespace,
-                "I" + NavTargetClass.Name + "Collection");
+            identifier = NamesService.GetCollectionInterfaceName(NavTargetClass);
+            NavTargetCollectionInterface = Proxy.GetInterface(NavTargetClass.Namespace, identifier.Name);
 
             NavTargetEntity = new EntityArtifacts()
             {

--- a/test/CSharpLiteWriterUnitTests/ObjectExtensions.cs
+++ b/test/CSharpLiteWriterUnitTests/ObjectExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 
@@ -53,11 +54,15 @@ namespace CSharpLiteWriterUnitTests
         }
 
         public static T InvokeMethod<T>(this object @object, string methodName, object[] args = null,
-            Type[] types = null)
+            Type[] types = null, string @interface = null)
         {
             args = args ?? new object[0];
 
-            var method = @object.GetType().GetMethod(methodName);
+            var type = @object.GetType();
+            var method = string.IsNullOrEmpty(@interface)
+                ? @object.GetType().GetMethod(methodName)
+                : type.GetInterface(@interface).GetMethod(methodName);
+
             if (types != null)
                 method = method.MakeGenericMethod(types);
 
@@ -69,9 +74,9 @@ namespace CSharpLiteWriterUnitTests
             return @object.InvokeMethod("get_Item", args);
         }
 
-        public static T GetIndexerValue<T>(this object @object, object[] args = null)
+        public static T GetIndexerValue<T>(this object @object, object[] args = null, string @interface = null)
         {
-            return @object.InvokeMethod<T>("get_Item", args: args);
+            return @object.InvokeMethod<T>("get_Item", args: args, @interface: @interface);
         }
 
         public static void ValidateCollectionPropertyValues(this object collection, IList<IEnumerable<Tuple<string, object>>> entitiesProperties)

--- a/test/CSharpLiteWriterUnitTests/OdcmTestExtensions.cs
+++ b/test/CSharpLiteWriterUnitTests/OdcmTestExtensions.cs
@@ -62,10 +62,7 @@ namespace CSharpLiteWriterUnitTests
                 {
                     Class = originalProperty.Class,
                     ReadOnly = originalProperty.ReadOnly,
-                    Projection = new OdcmProjection()
-                    {
-                        Type = originalProperty.Type
-                    },
+                    Projection = originalProperty.Type.DefaultProjection,
                     ContainsTarget = originalProperty.ContainsTarget,
                     IsCollection = originalProperty.IsCollection,
                     IsLink = originalProperty.IsLink,

--- a/test/CSharpWriterUnitTests/Given_a_ConfigurationProvider.cs
+++ b/test/CSharpWriterUnitTests/Given_a_ConfigurationProvider.cs
@@ -483,10 +483,7 @@ namespace CSharpWriterUnitTests
                             {
                                 Class = property.Class,
                                 ReadOnly = property.ReadOnly,
-                                Projection = new OdcmProjection()
-                                {
-                                    Type = property.Type
-                                }
+                                Projection = property.Type.DefaultProjection
                             };
 
                         cl.Properties.Add(lowerCaseProperty);

--- a/test/CSharpWriterUnitTests/Given_an_OdcmNamespace.cs
+++ b/test/CSharpWriterUnitTests/Given_an_OdcmNamespace.cs
@@ -69,10 +69,7 @@ namespace CSharpWriterUnitTests
             @class.Properties.Add(new OdcmProperty(Any.CSharpIdentifier())
             {
                 Class = @class,
-                Projection = new OdcmProjection()
-                {
-                    Type = @class
-                }
+                Projection = @class.DefaultProjection
             });
 
             _model.AddType(@class);

--- a/test/CSharpWriterUnitTests/OdcmTestExtensions.cs
+++ b/test/CSharpWriterUnitTests/OdcmTestExtensions.cs
@@ -62,10 +62,7 @@ namespace CSharpWriterUnitTests
                 {
                     Class = originalProperty.Class,
                     ReadOnly = originalProperty.ReadOnly,
-                    Projection = new OdcmProjection()
-                    {
-                        Type = originalProperty.Type
-                    },
+                    Projection = originalProperty.Type.DefaultProjection,
                     ContainsTarget = originalProperty.ContainsTarget,
                     IsCollection = originalProperty.IsCollection,
                     IsLink = originalProperty.IsLink,

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_Capability_Annotations.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_Capability_Annotations.cs
@@ -28,12 +28,38 @@ namespace ODataReader.v4UnitTests
 
             odcmEntitySet.Projection.Capabilities
                 .Should()
-                .BeEquivalentTo(OdcmCapability.DefaultOdcmCapabilities,
+                .BeEquivalentTo(OdcmCapability.DefaultEntitySetCapabilities,
                 "because an entity set without any capability annotation should have default capabilities");
 
             odcmEntityType.Projections
                 .Should()
                 .Contain(odcmEntitySet.Projection, "because entity set's Projection is retrieved from its OdcmType's cache of Projections");
+        }
+
+        [Fact]
+        public void When_Singleton_has_no_Capability_Annotation_Then_Its_OdcmProperty_has_all_the_default_OdcmCapabilities()
+        {
+            var entityTypeElement = _entityTypeElements.RandomElement();
+            var singletonElement = Any.Csdl.Singleton();
+            var singletonName = singletonElement.GetAttribute("Name");
+            singletonElement.AddAttribute("Type",
+                string.Format("{0}.{1}", _schemaNamespace, entityTypeElement.GetAttribute("Name")));
+            _entityContainerElement.Add(singletonElement);
+
+            var odcmModel = GetOdcmModel(_edmxElement);
+            var odcmEntityContainer = GetOdcmEntityContainer(odcmModel);
+
+            var odcmSingleton = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == singletonName);
+            OdcmType odcmEntityType = odcmSingleton.Projection.Type;
+
+            odcmSingleton.Projection.Capabilities
+                .Should()
+                .BeEquivalentTo(OdcmCapability.DefaultSingletonCapabilities,
+                "because a singleton without any capability annotation should have default capabilities");
+
+            odcmEntityType.Projections
+                .Should()
+                .Contain(odcmSingleton.Projection, "because Singleton's Projection is retrieved from its OdcmType's cache of Projections");
         }
 
         [Fact]
@@ -54,7 +80,7 @@ namespace ODataReader.v4UnitTests
 
             odcmNavProperty.Projection.Capabilities
                 .Should()
-                .BeEquivalentTo(OdcmCapability.DefaultOdcmCapabilities,
+                .BeEquivalentTo(OdcmCapability.DefaultPropertyCapabilities,
                 "because a navigation property without any capability annotation should have default capabilities");
 
             odcmNavProperty.Projection.Type.Projections
@@ -155,31 +181,7 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
-        public void When_NavigationProperty_has_InsertRestriction_Then_Its_OdcmProperty_has_OdcmInsertCapability()
-        {
-            var entitySetElement = _entitySetToEntityTypeMapping.Keys.RandomElement();
-            var entityTypeElement = _entitySetToEntityTypeMapping[entitySetElement];
-            var entityTypeElementName = entityTypeElement.GetAttribute("Name");
-            var navPropertyName = GetRandomNavigationProperty(entityTypeElement);
-
-            var insertable = Any.Bool();
-            entitySetElement.Add(Any.Csdl.InsertRestrictionAnnotation(insertable, new List<string> { navPropertyName }));
-
-            var odcmModel = GetOdcmModel(_edmxElement);
-            OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
-            OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
-
-            HasOdcmCapability<OdcmInsertCapability>(odcmNavProperty, false)
-                .Should()
-                .BeTrue("Because a navigation property with insert annotation should have OdcmInsertCapability");
-
-            odcmNavProperty.Projection.Type.Projections
-                .Should()
-                .Contain(odcmNavProperty.Projection, "because navigation property's Projection is retrieved from its OdcmType's cache of Projections");
-        }
-
-        [Fact]
-        public void When_NavigationProperty_has_UpdateRestriction_Then_Its_OdcmProperty_has_OdcmUpdateCapability()
+        public void When_NavigationProperty_is_annotated_with_NonUpdatableNavigationProperties_Then_Its_OdcmProperty_has_OdcmUpdateLinkCapability()
         {
             var entitySetElement = _entitySetToEntityTypeMapping.Keys.RandomElement();
             var entityTypeElement = _entitySetToEntityTypeMapping[entitySetElement];
@@ -193,9 +195,9 @@ namespace ODataReader.v4UnitTests
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            HasOdcmCapability<OdcmUpdateCapability>(odcmNavProperty, false)
+            HasOdcmCapability<OdcmUpdateLinkCapability>(odcmNavProperty, false)
                 .Should()
-                .BeTrue("Because a navigation property with update annotation should have OdcmUpdateCapability");
+                .BeTrue("Because a navigation property with update annotation should have OdcmUpdateLinkCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -203,7 +205,7 @@ namespace ODataReader.v4UnitTests
         }
 
         [Fact]
-        public void When_NavigationProperty_has_DeleteRestriction_Then_Its_OdcmProperty_has_OdcmDeleteCapability()
+        public void When_NavigationProperty_is_annotated_with_NonDeletableNavigationProperties_Then_Its_OdcmProperty_has_OdcmDeleteLinkCapability()
         {
             var entitySetElement = _entitySetToEntityTypeMapping.Keys.RandomElement();
             var entityTypeElement = _entitySetToEntityTypeMapping[entitySetElement];
@@ -217,33 +219,9 @@ namespace ODataReader.v4UnitTests
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            HasOdcmCapability<OdcmDeleteCapability>(odcmNavProperty, false)
+            HasOdcmCapability<OdcmDeleteLinkCapability>(odcmNavProperty, false)
                 .Should()
                 .BeTrue("Because a navigation property with delete annotation should have OdcmDeleteCapability");
-
-            odcmNavProperty.Projection.Type.Projections
-                .Should()
-                .Contain(odcmNavProperty.Projection, "because navigation property's Projection is retrieved from its OdcmType's cache of Projections");
-        }
-
-        [Fact]
-        public void When_NavigationProperty_has_ExpandRestriction_Then_Its_OdcmProperty_has_OdcmExpandCapability()
-        {
-            var entitySetElement = _entitySetToEntityTypeMapping.Keys.RandomElement();
-            var entityTypeElement = _entitySetToEntityTypeMapping[entitySetElement];
-            var entityTypeElementName = entityTypeElement.GetAttribute("Name");
-            var navPropertyName = GetRandomNavigationProperty(entityTypeElement);
-
-            var expandable = Any.Bool();
-            entitySetElement.Add(Any.Csdl.ExpandRestrictionAnnotation(expandable, new List<string> { navPropertyName }));
-
-            var odcmModel = GetOdcmModel(_edmxElement);
-            OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
-            OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
-
-            HasOdcmCapability<OdcmExpandCapability>(odcmNavProperty, false)
-                .Should()
-                .BeTrue("Because a navigation property with expand annotation should have OdcmExpandCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -255,7 +233,6 @@ namespace ODataReader.v4UnitTests
         {
             var booleanValue = Any.Bool();
             var randomRestrictionAnnotations = GetRandomRestrictionAnnotationElements(booleanValue, null);
-            int annotationCount = randomRestrictionAnnotations.Count();
 
             var entitySetElement = _entitySetToEntityTypeMapping.Keys.RandomElement();
             var entitySetElementName = entitySetElement.GetAttribute("Name");
@@ -266,13 +243,6 @@ namespace ODataReader.v4UnitTests
 
             var odcmEntitySet = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == entitySetElementName);
             OdcmType odcmEntityType = odcmEntitySet.Projection.Type;
-
-            odcmEntitySet.Projection.Capabilities.Count
-                .Should()
-                .Be(annotationCount,
-                    string.Format(
-                        "Because an entity set with {0} restriction annotations should have {0} OdcmCapabilities",
-                        annotationCount));
 
             foreach (var restrictionAnnotation in randomRestrictionAnnotations)
             {
@@ -295,30 +265,22 @@ namespace ODataReader.v4UnitTests
             var entityTypeElementName = entityTypeElement.GetAttribute("Name");
             var navPropertyName = GetRandomNavigationProperty(entityTypeElement);
 
-            var randomRestrictionAnnotations = GetRandomRestrictionAnnotationElements(Any.Bool(),
-                new List<string> { navPropertyName });
-            int annotationCount = randomRestrictionAnnotations.Count();
-
-            entitySetElement.Add(randomRestrictionAnnotations);
+            entitySetElement.Add(Any.Csdl.UpdateRestrictionAnnotation(Any.Bool(),
+                new List<string> { navPropertyName }));
+            entitySetElement.Add(Any.Csdl.DeleteRestrictionAnnotation(Any.Bool(),
+                new List<string> { navPropertyName }));
 
             var odcmModel = GetOdcmModel(_edmxElement);
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            odcmNavProperty.Projection.Capabilities.Count
-               .Should()
-               .Be(annotationCount,
-                   string.Format(
-                       "Because a navigation property with {0} restriction annotations should have {0} OdcmCapabilities",
-                       annotationCount));
-
-            foreach (var restrictionAnnotation in randomRestrictionAnnotations)
-            {
-                Type capabilityType = GetCapabilityTypeForAnnotation(restrictionAnnotation);
-                HasOdcmCapability(odcmNavProperty, capabilityType, false)
+            HasOdcmCapability<OdcmUpdateLinkCapability>(odcmNavProperty, false)
                     .Should()
-                    .BeTrue("Because a navigation property should have the correct OdcmCapability");
-            }
+                    .BeTrue("Because a navigation property should have the correct OdcmUpdateLinkCapability");
+
+            HasOdcmCapability<OdcmDeleteLinkCapability>(odcmNavProperty, false)
+                    .Should()
+                    .BeTrue("Because a navigation property should have the correct OdcmDeleteLinkCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -353,18 +315,14 @@ namespace ODataReader.v4UnitTests
 
             // Scenario where they share one restriction annotation, but have two other different restriction annotation
             // This must create two different projections for these navigation properties
-            entitySetElement.Add(Any.Csdl.UpdateRestrictionAnnotation(Any.Bool(),
+            entitySetElement.Add(Any.Csdl.InsertRestrictionAnnotation(Any.Bool(),
                 new List<string> { navPropertyElement1Name, navPropertyElement2Name }));
-            entitySetElement.Add(Any.Csdl.ExpandRestrictionAnnotation(Any.Bool(), new List<string> { navPropertyElement1Name }));
-            entitySetElement.Add(Any.Csdl.InsertRestrictionAnnotation(Any.Bool(), new List<string> { navPropertyElement2Name }));
+            entitySetElement.Add(Any.Csdl.UpdateRestrictionAnnotation(Any.Bool(), new List<string> { navPropertyElement1Name }));
+            entitySetElement.Add(Any.Csdl.DeleteRestrictionAnnotation(Any.Bool(), new List<string> { navPropertyElement2Name }));
 
             var odcmModel = GetOdcmModel(_edmxElement);
             OdcmType odcmType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmType odcmNavPropertyType = GetOdcmEntityType(odcmModel, navigationPropertyTypeName);
-
-            odcmNavPropertyType.Projections.Count()
-                .Should()
-                .Be(3, "Because the OdcmModel must create 3 propjections including the Projection with Default Capabilities");
 
             OdcmProperty odcmNavProperty1 = (odcmType as OdcmClass).Properties.Single(p => p.Name == navPropertyElement1Name);
             OdcmProperty odcmNavProperty2 = (odcmType as OdcmClass).Properties.Single(p => p.Name == navPropertyElement2Name);
@@ -411,10 +369,11 @@ namespace ODataReader.v4UnitTests
             entityTypeElement.Add(navPropertyElement1);
             entityTypeElement.Add(navPropertyElement2);
 
-            // make sure that these two navigation properites have different restriction annotation
-            var annotations = GetRandomRestrictionAnnotationElements(Any.Bool(),
-                new List<string> { navPropertyElement1Name, navPropertyElement2Name });
-            entitySetElement.Add(annotations);
+            // make sure that these two navigation properites have same restriction annotation
+            entitySetElement.Add(Any.Csdl.UpdateRestrictionAnnotation(Any.Bool(),
+                new List<string> {navPropertyElement1Name, navPropertyElement2Name}));
+            entitySetElement.Add(Any.Csdl.DeleteRestrictionAnnotation(Any.Bool(),
+                new List<string> {navPropertyElement1Name, navPropertyElement2Name}));
 
             var odcmModel = GetOdcmModel(_edmxElement);
             OdcmType odcmType = GetOdcmEntityType(odcmModel, entityTypeElementName);
@@ -422,7 +381,7 @@ namespace ODataReader.v4UnitTests
 
             odcmNavPropertyType.Projections.Count()
                 .Should()
-                .Be(2, "Because the OdcmModel must create 2 propjections including the Projection with Default Capabilities");
+                .Be(2, "Because the OdcmModel must create 2 projections including the Projection with Default Capabilities");
 
             OdcmProperty odcmNavProperty1 = (odcmType as OdcmClass).Properties.Single(p => p.Name == navPropertyElement1Name);
             OdcmProperty odcmNavProperty2 = (odcmType as OdcmClass).Properties.Single(p => p.Name == navPropertyElement2Name);
@@ -450,13 +409,15 @@ namespace ODataReader.v4UnitTests
             _entityContainerName = _entityContainerElement.Attribute("Name").Value;
 
             string entityTypesEdmx = string.Format(ENTITY_TYPES_EDMX, _schemaNamespace);
-            IEnumerable<XElement> entityTypeElements = XElement.Parse(entityTypesEdmx).Elements().Where(element => element.Name.LocalName == "EntityType");
+            _entityTypeElements =
+                XElement.Parse(entityTypesEdmx).Elements().Where(element => element.Name.LocalName == "EntityType");
 
-            foreach (var entityTypeElement in entityTypeElements)
+            foreach (var entityTypeElement in _entityTypeElements)
             {
                 _schema.Add(entityTypeElement);
                 var entitySetElement = Any.Csdl.EntitySet();
-                entitySetElement.AddAttribute("EntityType", string.Format("{0}.{1}", _schemaNamespace, entityTypeElement.GetAttribute("Name")));
+                entitySetElement.AddAttribute("EntityType",
+                    string.Format("{0}.{1}", _schemaNamespace, entityTypeElement.GetAttribute("Name")));
                 _entitySetToEntityTypeMapping.Add(entitySetElement, entityTypeElement);
                 _entityContainerElement.Add(entitySetElement);
             }
@@ -471,6 +432,7 @@ namespace ODataReader.v4UnitTests
         private XElement _schema;
         private XElement _entityContainerElement;
         private Dictionary<XElement, XElement> _entitySetToEntityTypeMapping;
+        private IEnumerable<XElement> _entityTypeElements;
 
 
         private const string ENTITY_TYPES_EDMX =
@@ -573,6 +535,13 @@ namespace ODataReader.v4UnitTests
         {
             Type returnType = null;
             var termName = GetAnnotationTermName(annotation);
+
+            return GetCapabilityTypeForAnnotation(termName);
+        }
+
+        private Type GetCapabilityTypeForAnnotation(string termName)
+        {
+            Type returnType = null;
 
             var odcmCapability = OdcmCapability.DefaultOdcmCapabilities.SingleOrDefault(
                 capability => capability.TermName == termName);

--- a/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_Capability_Annotations.cs
+++ b/test/ODataReader.v4UnitTests/Given_a_valid_edmx_with_Capability_Annotations.cs
@@ -34,6 +34,11 @@ namespace ODataReader.v4UnitTests
             odcmEntityType.Projections
                 .Should()
                 .Contain(odcmEntitySet.Projection, "because entity set's Projection is retrieved from its OdcmType's cache of Projections");
+
+            odcmEntityType.DefaultProjection.Capabilities
+                .Should()
+                .BeEquivalentTo(OdcmCapability.DefaultOdcmCapabilities,
+                    "because every OdcmType should have a default Projection with default capabilities");
         }
 
         [Fact]
@@ -60,6 +65,11 @@ namespace ODataReader.v4UnitTests
             odcmEntityType.Projections
                 .Should()
                 .Contain(odcmSingleton.Projection, "because Singleton's Projection is retrieved from its OdcmType's cache of Projections");
+
+            odcmEntityType.DefaultProjection.Capabilities
+                .Should()
+                .BeEquivalentTo(OdcmCapability.DefaultOdcmCapabilities,
+                    "because every OdcmType should have a default Projection with default capabilities");
         }
 
         [Fact]
@@ -86,6 +96,11 @@ namespace ODataReader.v4UnitTests
             odcmNavProperty.Projection.Type.Projections
                 .Should()
                 .Contain(odcmNavProperty.Projection, "because navigation property's Projection is retrieved from its OdcmType's cache of Projections");
+
+            odcmEntityType.DefaultProjection.Capabilities
+                .Should()
+                .BeEquivalentTo(OdcmCapability.DefaultOdcmCapabilities,
+                    "because every OdcmType should have a default Projection with default capabilities");
         }
 
         [Fact]
@@ -102,9 +117,9 @@ namespace ODataReader.v4UnitTests
             var odcmEntitySet = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == entitySetElementName);
             OdcmType odcmEntityType = odcmEntitySet.Projection.Type;
 
-            HasOdcmCapability<OdcmInsertCapability>(odcmEntitySet, insertable)
+            odcmEntitySet.Projection.SupportsInsert()
                 .Should()
-                .BeTrue("Because an entity set with insert annotation should have OdcmInsertCapability");
+                .Be(insertable, "Because an entity set with insert annotation should have OdcmInsertCapability");
 
             odcmEntityType.Projections
                 .Should()
@@ -125,9 +140,9 @@ namespace ODataReader.v4UnitTests
             var odcmEntitySet = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == entitySetElementName);
             OdcmType odcmEntityType = odcmEntitySet.Projection.Type;
 
-            HasOdcmCapability<OdcmUpdateCapability>(odcmEntitySet, updatable)
+            odcmEntitySet.Projection.SupportsUpdate()
                 .Should()
-                .BeTrue("Because an entity set with update annotation should have OdcmUpdateCapability");
+                .Be(updatable, "Because an entity set with update annotation should have OdcmUpdateCapability");
 
             odcmEntityType.Projections
                 .Should()
@@ -148,9 +163,9 @@ namespace ODataReader.v4UnitTests
             var odcmEntitySet = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == entitySetElementName);
             OdcmType odcmEntityType = odcmEntitySet.Projection.Type;
 
-            HasOdcmCapability<OdcmDeleteCapability>(odcmEntitySet, deletable)
+            odcmEntitySet.Projection.SupportsDelete()
                 .Should()
-                .BeTrue("Because an entity set with delete annotation should have OdcmDeleteCapability");
+                .Be(deletable, "Because an entity set with delete annotation should have OdcmDeleteCapability");
 
             odcmEntityType.Projections
                 .Should()
@@ -171,9 +186,9 @@ namespace ODataReader.v4UnitTests
             var odcmEntitySet = odcmEntityContainer.As<OdcmClass>().Properties.Single(p => p.Name == entitySetElementName);
             OdcmType odcmEntityType = odcmEntitySet.Projection.Type;
 
-            HasOdcmCapability<OdcmExpandCapability>(odcmEntitySet, expandable)
-                            .Should()
-                            .BeTrue("Because an entity set with expand annotation should have OdcmExpandCapability");
+            odcmEntitySet.Projection.SupportsExpand()
+                .Should()
+                .Be(expandable, "Because an entity set with expand annotation should have OdcmExpandCapability");
 
             odcmEntityType.Projections
                 .Should()
@@ -195,9 +210,9 @@ namespace ODataReader.v4UnitTests
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            HasOdcmCapability<OdcmUpdateLinkCapability>(odcmNavProperty, false)
+            odcmNavProperty.Projection.SupportsUpdateLink()
                 .Should()
-                .BeTrue("Because a navigation property with update annotation should have OdcmUpdateLinkCapability");
+                .BeFalse("Because a navigation property with update annotation should not support OdcmUpdateLinkCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -219,9 +234,9 @@ namespace ODataReader.v4UnitTests
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            HasOdcmCapability<OdcmDeleteLinkCapability>(odcmNavProperty, false)
+            odcmNavProperty.Projection.SupportsDeleteLink()
                 .Should()
-                .BeTrue("Because a navigation property with delete annotation should have OdcmDeleteCapability");
+                .BeFalse("Because a navigation property with delete annotation should not support OdcmDeleteCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -274,13 +289,13 @@ namespace ODataReader.v4UnitTests
             OdcmType odcmEntityType = GetOdcmEntityType(odcmModel, entityTypeElementName);
             OdcmProperty odcmNavProperty = (odcmEntityType as OdcmClass).Properties.Single(p => p.Name == navPropertyName);
 
-            HasOdcmCapability<OdcmUpdateLinkCapability>(odcmNavProperty, false)
+            odcmNavProperty.Projection.SupportsUpdateLink()
                     .Should()
-                    .BeTrue("Because a navigation property should have the correct OdcmUpdateLinkCapability");
+                    .BeFalse("Because a navigation property should have the correct OdcmUpdateLinkCapability");
 
-            HasOdcmCapability<OdcmDeleteLinkCapability>(odcmNavProperty, false)
+            odcmNavProperty.Projection.SupportsDeleteLink()
                     .Should()
-                    .BeTrue("Because a navigation property should have the correct OdcmDeleteLinkCapability");
+                    .BeFalse("Because a navigation property should have the correct OdcmDeleteLinkCapability");
 
             odcmNavProperty.Projection.Type.Projections
                 .Should()
@@ -562,11 +577,6 @@ namespace ODataReader.v4UnitTests
             });
 
             return odcmCapability != null;
-        }
-
-        private bool HasOdcmCapability<T>(OdcmProperty odcmProperty, bool booleanValue) where T : OdcmBooleanCapability
-        {
-            return HasOdcmCapability(odcmProperty, typeof(T), booleanValue);
         }
     }
 }


### PR DESCRIPTION
- The OdcmModel now supports these two additional capabilities.
- The OdataReader now sets default capabilities for EntitySet, Singleton and NavigationProperties.
- Each OdcmProperty starts with a default set of capabilities and then based on annotations their capabilities are mutated.
- Creating Projections for a property is now done after parsing the entire EdmModel when we have deterministic view of all the capabilities of all the properties.