### PR TITLE
Add support for function overrides

### DIFF
--- a/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmMethod.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Vipr.Core.CodeModel
 {
     public class OdcmMethod : OdcmType
     {
+        private static List<OdcmParameter> EmptyParameters = new List<OdcmParameter>();
         public OdcmClass Class { get; set; }
 
         public OdcmAllowedVerbs Verbs { get; set; }
@@ -19,6 +21,8 @@ namespace Vipr.Core.CodeModel
 
         public bool IsStatic { get; set; }
 
+        public IList<OdcmMethod> Overloads { get; private set; }
+
         public List<OdcmParameter> Parameters { get; private set; }
 
         public OdcmType ReturnType { get; set; }
@@ -29,6 +33,7 @@ namespace Vipr.Core.CodeModel
             : base(name, @namespace)
         {
             Parameters = new List<OdcmParameter>();
+            Overloads = new List<OdcmMethod>();
         }
 
         public override string CanonicalName()


### PR DESCRIPTION
Any firstly parsed overloaded OdcmMethod instance would have a list of OdcmMethods with other overloads for the same method. Only this first instance is visible on OdcmClass.

This should help to fix https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/19
