### PR TITLE
Fix for #125.

### DIFF
--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -27,10 +27,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
 
         public void  ParseCapabilityAnnotation(OdcmObject odcmObject, IEdmValueAnnotation annotation)
         {
-            if (annotation.Term.Name != "Description" && annotation.Term.Name != "LongDescription")
-            {
-                TryParseCapability(odcmObject, annotation.Value, annotation.Term.FullName());
-            }
+            TryParseCapability(odcmObject, annotation.Value, annotation.Term.FullName());
         }
 
         private bool HasSpecializedParser(OdcmObject odcmObject, IEdmExpression expression, string annotationTerm)
@@ -205,7 +202,14 @@ namespace Vipr.Reader.OData.v4.Capabilities
         private void AddCapability(OdcmObject odcmObject, OdcmCapability capability)
         {
             var capabilities = _propertyCapabilitiesCache.GetCapabilities(odcmObject);
-            capabilities.Add(capability);
+
+            // Check if this annotation was overridden by the object
+            bool overridden = capabilities.Any(x => x.TermName == capability.TermName);
+
+            if (!overridden)
+            {
+                capabilities.Add(capability);
+            }
         }
 
         private OdcmProperty PropertyFromPathExpression(IEdmPathExpression pathExpression, OdcmObject odcmObject)


### PR DESCRIPTION
When ODATA lib returns a list of vocabulary annotations for an EntityType, this list consists of all annotations defined for this type plus all annotations inherited from its base types. The type annotations and the inherited annotations differ by their Target property. The annotation list is parsed by VIPR into Projection for a OdcmClass object. However, VIPR requires only one copy of a particular annotation type to be present in any OdcmObject.Projection list.

This particular crash is caused by redefinition of a base EntityType annotation by its derived class.

The fix takes into account that base type annotations can be redefined (or overridden) by derived types.The OdcmObject.Projection for any type would contain base type annotation only if this annotation hasn't been redefined or overridden by this type.

The change also adds a new unit test for annotation inheritance scenario.