### PR TITLE
Catch non-fatal errors

### DIFF
--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -173,7 +173,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
+                    Logger.Error(e, e.Message);
                 }
             }
         }
@@ -222,7 +222,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Logger.Error(e, e.Message);
             }
         }
 

--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -26,7 +26,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
             _propertyCapabilitiesCache = propertyCapabilitiesCache;
         }
 
-        public void  ParseCapabilityAnnotation(OdcmObject odcmObject, IEdmValueAnnotation annotation)
+        public void ParseCapabilityAnnotation(OdcmObject odcmObject, IEdmValueAnnotation annotation)
         {
             TryParseCapability(odcmObject, annotation.Value, annotation.Term.FullName());
         }
@@ -162,12 +162,18 @@ namespace Vipr.Reader.OData.v4.Capabilities
                 var pathExpression = (IEdmPathExpression) recordExpression.Properties
                                                 .First(p => p.Value is IEdmPathExpression)
                                                 .Value;
-
-                var odcmProperty = SetPathCapability(odcmObject, pathExpression, annotationTerm);
-
-                foreach (var propertyConstructor in recordExpression.Properties.Where(p => !(p.Value is IEdmPathExpression)))
+                try
                 {
-                    TryParseCapability(odcmProperty, propertyConstructor.Value, annotationTerm + "/" + propertyConstructor.Name);
+                    var odcmProperty = SetPathCapability(odcmObject, pathExpression, annotationTerm);
+
+                    foreach (var propertyConstructor in recordExpression.Properties.Where(p => !(p.Value is IEdmPathExpression)))
+                    {
+                        TryParseCapability(odcmProperty, propertyConstructor.Value, annotationTerm + "/" + propertyConstructor.Name);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.Message);
                 }
             }
         }
@@ -202,14 +208,21 @@ namespace Vipr.Reader.OData.v4.Capabilities
 
         private void AddCapability(OdcmObject odcmObject, OdcmCapability capability)
         {
-            var capabilities = _propertyCapabilitiesCache.GetCapabilities(odcmObject);
-
-            // Check if this annotation was overridden by the object
-            bool overridden = capabilities.Any(x => x.TermName == capability.TermName);
-
-            if (!overridden)
+            try
             {
-                capabilities.Add(capability);
+                var capabilities = _propertyCapabilitiesCache.GetCapabilities(odcmObject);
+
+                // Check if this annotation was overridden by the object
+                bool overridden = capabilities.Any(x => x.TermName == capability.TermName);
+
+                if (!overridden)
+                {
+                    capabilities.Add(capability);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
             }
         }
 

--- a/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
@@ -354,9 +354,9 @@ namespace Vipr.Reader.OData.v4
                     {
                         _propertyCapabilitiesCache.Add(odcmClass, new List<OdcmCapability>());
                     }
-                    catch (Exception e)
+                    catch (InvalidOperationException e)
                     {
-                        Logger.Error(e, e.Message);
+                        Logger.Warn("Failed to add property to cahce", e);
                     }
                     AddVocabularyAnnotations(odcmClass, entityContainer);
 
@@ -552,9 +552,9 @@ namespace Vipr.Reader.OData.v4
                     {
                         _propertyCapabilitiesCache.Add(odcmProperty, OdcmCapability.DefaultEntitySetCapabilities);
                     }
-                    catch (Exception e)
+                    catch (InvalidOperationException e)
                     {
-                        Logger.Error(e, e.Message);
+                        Logger.Warn("Failed to add property to cache", e);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, entitySet);
@@ -562,9 +562,9 @@ namespace Vipr.Reader.OData.v4
                     odcmClass.Properties.Add(odcmProperty);
                 }
                 // If we hit an invalid type, skip this property
-                catch (Exception e)
+                catch (InvalidOperationException e)
                 {
-                    Logger.Error(e, e.Message);
+                    Logger.Error("Could not resolve type", e);
                 }
             }
 
@@ -589,18 +589,18 @@ namespace Vipr.Reader.OData.v4
                     {
                         _propertyCapabilitiesCache.Add(odcmProperty, OdcmCapability.DefaultSingletonCapabilities);
                     }
-                    catch (Exception e)
+                    catch (InvalidOperationException e)
                     {
-                        Logger.Error(e, e.Message);
+                        Logger.Warn("Failed to add property to cache", e);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, singleton);
 
                     odcmClass.Properties.Add(odcmProperty);
                 }
-                catch (Exception e)
+                catch (InvalidOperationException e)
                 {
-                    Logger.Error(e, e.Message);
+                    Logger.Error("Could not resolve type", e);
                 }
             }
 
@@ -703,18 +703,18 @@ namespace Vipr.Reader.OData.v4
                     {
                         _propertyCapabilitiesCache.Add(odcmProperty, OdcmCapability.DefaultPropertyCapabilities);
                     }
-                    catch (Exception e)
+                    catch (InvalidOperationException e)
                     {
-                        Logger.Error(e, e.Message);
+                        Logger.Warn("Failed to add property to cache", e);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, property);
 
                     odcmClass.Properties.Add(odcmProperty);
                 }
-                catch (Exception e)
+                catch (InvalidOperationException e)
                 {
-                    Logger.Error(e, e.Message);
+                    Logger.Error("Could not resolve type", e);
                 }
             }
 
@@ -769,9 +769,9 @@ namespace Vipr.Reader.OData.v4
                     {
                         _propertyCapabilitiesCache.Add(odcmObject, OdcmCapability.DefaultEntitySetCapabilities);
                     }
-                    catch (Exception e)
+                    catch (InvalidOperationException e)
                     {
-                        Logger.Error(e, e.Message);
+                        Logger.Warn("Failed to add property to cache", e);
                     }
                 }
 

--- a/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/OdcmReader.cs
@@ -157,7 +157,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
                 }
             }
@@ -356,7 +356,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
                     AddVocabularyAnnotations(odcmClass, entityContainer);
 
@@ -554,7 +554,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, entitySet);
@@ -564,7 +564,7 @@ namespace Vipr.Reader.OData.v4
                 // If we hit an invalid type, skip this property
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
+                    Logger.Error(e, e.Message);
                 }
             }
 
@@ -591,7 +591,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, singleton);
@@ -600,7 +600,7 @@ namespace Vipr.Reader.OData.v4
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
+                    Logger.Error(e, e.Message);
                 }
             }
 
@@ -705,7 +705,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
 
                     AddVocabularyAnnotations(odcmProperty, property);
@@ -714,7 +714,7 @@ namespace Vipr.Reader.OData.v4
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
+                    Logger.Error(e, e.Message);
                 }
             }
 
@@ -771,7 +771,7 @@ namespace Vipr.Reader.OData.v4
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine(e.Message);
+                        Logger.Error(e, e.Message);
                     }
                 }
 

--- a/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -7,6 +7,7 @@ using Vipr.Reader.OData.v4;
 using System.Linq;
 using Vipr.Core.CodeModel;
 using Xunit;
+using System.Xml.Linq;
 
 namespace ODataReader.v4UnitTests
 {
@@ -304,6 +305,51 @@ namespace ODataReader.v4UnitTests
                 .BeAssignableTo<OdcmEntityClass>("because entity types should result in an OdcmClass");
 
             return odcmEntityType;
+        }
+
+        [Fact]
+        public void When_property_is_invalid_it_skips_addition()
+        {
+            var entityNamespace = Any.Csdl.EntityContainer().Attribute("Name").Value.ToString();
+
+            var customPropertyName = string.Empty;
+
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) =>
+                {
+                    var property = Any.Csdl.Property(entityNamespace + ".invalid");
+                    customPropertyName = property.Attribute("Name").Value;
+                    entityType.Add(property);
+                });
+
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+
+            var createdType = odcmModel.EntityContainer.Namespace.Types.Where(x => x.FullName == customPropertyName);
+
+            createdType.Should().BeEmpty("because the invalid property should have been skipped");
+        }
+
+        [Fact]
+        public void When_primitive_does_not_exist_it_skips_addition()
+        {
+            var customPropertyName = string.Empty;
+
+            var testCase = new EdmxTestCase()
+                .AddEntityType(EdmxTestCase.Keys.EntityType, (_, entityType) =>
+                {
+                    var property = Any.Csdl.Property("Edm.Boolean!");
+                    customPropertyName = property.Attribute("Name").Value;
+                    entityType.Add(property);
+                });
+
+            var odcmModel = _odcmReader.GenerateOdcmModel(testCase.ServiceMetadata());
+
+            var createdType = odcmModel.EntityContainer.Namespace.Types.Where(x => x.FullName == customPropertyName);
+
+            var createdPrimitive = odcmModel.EntityContainer.Namespace.Classes.Where(x => x.Properties.Where(y => y.Type.FullName == "Edm.Boolean!").Count() > 0);
+
+            createdType.Should().BeEmpty("because the invalid property should have been skipped");
+            createdPrimitive.Should().BeEmpty("because the invalid primitive should have been skipped");
         }
     }
 }


### PR DESCRIPTION
In order to continue the generation process, try/catches allow us to log the issues appropriately but continue generating. 