### PR TITLE
Add error tests for properties and primitives

### DIFF
--- a/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_entity_types_in_a_valid_edmx_when_passed_to_the_ODataReader.cs
@@ -351,23 +351,5 @@ namespace ODataReader.v4UnitTests
             createdType.Should().BeEmpty("because the invalid property should have been skipped");
             createdPrimitive.Should().BeEmpty("because the invalid primitive should have been skipped");
         }
-
-        [Fact]
-        public void When_entityset_property_is_invalid_it_skips_addition()
-        {
-
-        }
-
-        [Fact]
-        public void When_singleton_property_is_invalid_it_skips_addition()
-        {
-
-        }
-
-        [Fact]
-        public void When_property_cannot_be_written_to_cache_it_skips_addition()
-        {
-
-        }
     }
 }


### PR DESCRIPTION
These two tests cover the most common Vipr crash scenarios and validate error-handling branch changes.

If we want full test coverage, we will need to create constructors for EntitySets and Singletons, as well as write capability annotation tests.