### PR TITLE
Remove BOM from encoding

### DIFF
--- a/src/Core/Vipr/FileWriter.cs
+++ b/src/Core/Vipr/FileWriter.cs
@@ -92,7 +92,7 @@ namespace Vipr
             var lockItem = lockDictionary.GetOrAdd(filePath, new Lazy<AsyncLock>());
             using (await lockItem.Value.LockAsync())
             {
-                using (StreamWriter sw = new StreamWriter(filePath, false, Encoding.UTF8))
+                using (StreamWriter sw = new StreamWriter(filePath, false, new UTF8Encoding(false)))
                 {
                     await sw.WriteAsync(output);
                 }


### PR DESCRIPTION
The default encoding for UTF-8 is to include the BOM. Existing generated files do not include the BOM and Android Studio is unable to parse this additional data.