### PR TITLE
Update ODataLibs to 7.5.0, refactor, add support for NavigationPropertyBindings, fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,5 @@ FakesAssemblies/
 *.v2.ncrunchproject
 *.v2.ncrunchsolution
 /Vipr.sln.GhostDoc.xml
-/.vs/config
+/.vs
 

--- a/src/Core/Vipr.Core/CodeModel/OdcmEntitySet.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmEntitySet.cs
@@ -1,12 +1,27 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Vipr.Core.CodeModel
 {
+    /// <summary>
+    /// Represents an OData entity set.
+    /// http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/cs01/odata-csdl-xml-v4.01-cs01.html#sec_EntitySet
+    /// </summary>
     public class OdcmEntitySet : OdcmProperty
     {
-        public OdcmEntitySet(string name) : base(name)
+        public OdcmEntitySet(string name) : this(name, null)
         {
         }
+
+        public OdcmEntitySet(string name, Dictionary<string, string> navigationPropertyBindings) : base(name)
+        {
+            // Adding NavigationPropertyBindings for generation hints.
+            // http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/cs01/odata-csdl-xml-v4.01-cs01.html#sec_NavigationPropertyBinding
+            NavigationPropertyBindings = navigationPropertyBindings;
+        }
+
+        public Dictionary<string, string> NavigationPropertyBindings { get; private set; }
     }
 }

--- a/src/Core/Vipr.Core/CodeModel/OdcmSingleton.cs
+++ b/src/Core/Vipr.Core/CodeModel/OdcmSingleton.cs
@@ -1,12 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Vipr.Core.CodeModel
 {
+    /// <summary>
+    /// Represents an OData singleton.
+    /// http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/cs01/odata-csdl-xml-v4.01-cs01.html#sec_Singleton
+    /// </summary>
     public class OdcmSingleton : OdcmProperty
     {
-        public OdcmSingleton(string name) : base(name)
+        public OdcmSingleton(string name) : this(name, null)
         {
+
         }
+
+        public OdcmSingleton(string name, Dictionary<string, string> navigationPropertyBindings) : base(name)
+        {
+            // Adding NavigationPropertyBindings for generation hints.
+            // http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/cs01/odata-csdl-xml-v4.01-cs01.html#sec_NavigationPropertyBinding
+            NavigationPropertyBindings = navigationPropertyBindings;
+        }
+
+        public Dictionary<string, string> NavigationPropertyBindings { get; private set; }
     }
 }

--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilitiesVocabularies.xml
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilitiesVocabularies.xml
@@ -1,4 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<edmx:Edmx Version="4.0"
+    xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
 <!--
 This helper code was provided by the OData.net team - Mark Stafford, Conyong Su and Sam Xu
 We should be able to remove this once they include it in WebApi OData
@@ -250,3 +252,5 @@ OM 1931609 - Remove ODataVocabularies helpers and CSDL files once WebApiOData in
   </ComplexType>
 
 </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -240,7 +240,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
             }
 
             var pathBuilder = new StringBuilder();
-            foreach (var path in pathExpression.Path)
+            foreach (var path in pathExpression.PathSegments)
             {
                 pathBuilder.AppendFormat("{0}.", path);
             }

--- a/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/Capabilities/CapabilityAnnotationParser.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
+using NLog;
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Text;
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Annotations;
-using Vipr.Core.CodeModel;
-using Microsoft.OData.Edm.Expressions;
 using Vipr.Core;
+using Vipr.Core.CodeModel;
 using Vipr.Core.CodeModel.Vocabularies.Capabilities;
-using System.Dynamic;
-using NLog;
 
 namespace Vipr.Reader.OData.v4.Capabilities
 {
@@ -26,7 +25,7 @@ namespace Vipr.Reader.OData.v4.Capabilities
             _propertyCapabilitiesCache = propertyCapabilitiesCache;
         }
 
-        public void ParseCapabilityAnnotation(OdcmObject odcmObject, IEdmValueAnnotation annotation)
+        public void ParseCapabilityAnnotation(OdcmObject odcmObject, IEdmVocabularyAnnotation annotation)
         {
             TryParseCapability(odcmObject, annotation.Value, annotation.Term.FullName());
         }

--- a/src/Readers/Vipr.Reader.OData.v4/ODataVocabularyReader.cs
+++ b/src/Readers/Vipr.Reader.OData.v4/ODataVocabularyReader.cs
@@ -1,20 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
-
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Annotations;
-using Microsoft.OData.Edm.Csdl;
-using Microsoft.OData.Edm.Evaluation;
-using Microsoft.OData.Edm.Expressions;
-using Microsoft.OData.Edm.Values;
-using Microsoft.OData.Edm.Validation;
 using Vipr.Core.CodeModel;
 
 namespace Vipr.Reader.OData.v4
@@ -42,7 +38,7 @@ namespace Vipr.Reader.OData.v4
             // TODO: As above, Extend / modify this to more clearly support custom annotation registration. 
             // Tracked by https://github.com/Microsoft/vipr/issues/59
             IEnumerable<EdmError> errors;
-            if (!CsdlReader.TryParse(new[] { XmlReader.Create(new StringReader(Vipr.Reader.OData.v4.Properties.Resources.CapabilitiesVocabularies)) }, out _capabilitiesModel, out errors))
+            if (!CsdlReader.TryParse(XmlReader.Create(new StringReader(Vipr.Reader.OData.v4.Properties.Resources.CapabilitiesVocabularies)), out _capabilitiesModel, out errors))
             {
                 throw new InvalidOperationException("Could not load capabilities vocabulary from resources");
             }
@@ -99,12 +95,12 @@ namespace Vipr.Reader.OData.v4
                     var elementType = _registeredVocabularyTypes[odcmAnnotation.Namespace][odcmAnnotation.Name];
 
                     // We have a delayedValue that will get us to the corresponding type of the annotation
-                    if (elementType.SchemaElementKind == EdmSchemaElementKind.ValueTerm && elementType is IEdmValueTerm)
+                    if (elementType.SchemaElementKind == EdmSchemaElementKind.Term && elementType is IEdmTerm)
                     {
-                        var valueTerm = (IEdmValueTerm)elementType;
+                        var valueTerm = (IEdmTerm)elementType;
                         var valueType = valueTerm.Type;
 
-                        var valueAnnotation = annotation as IEdmValueAnnotation;
+                        var valueAnnotation = annotation as IEdmVocabularyAnnotation;
 
                         if (valueAnnotation == null)
                         {

--- a/src/Readers/Vipr.Reader.OData.v4/Vipr.Reader.OData.v4.csproj
+++ b/src/Readers/Vipr.Reader.OData.v4/Vipr.Reader.OData.v4.csproj
@@ -33,13 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.OData.Edm, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.OData.Edm.6.11.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.OData.Client, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.OData.Client.7.5.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Spatial.6.11.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.OData.Core.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NLog.4.3.6\lib\net45\NLog.dll</HintPath>

--- a/src/Readers/Vipr.Reader.OData.v4/packages.config
+++ b/src/Readers/Vipr.Reader.OData.v4/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Client" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.11.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Client" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="NLog" version="4.3.6" targetFramework="net45" />
 </packages>

--- a/test/ODataReader.v4UnitTests/Given_an_ODataVocabularyReader.cs
+++ b/test/ODataReader.v4UnitTests/Given_an_ODataVocabularyReader.cs
@@ -1,27 +1,20 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-
-using FluentAssertions;
-
-using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Csdl;
-using Microsoft.OData.Edm.Library;
-using Microsoft.OData.Edm.Library.Values;
-using Microsoft.OData.Edm.Validation;
-using Microsoft.OData.Edm.Values;
-
-using Xunit;
-
-using Vipr.Reader.OData.v4;
-
 using Vipr.Core.CodeModel;
 using Vipr.Core.CodeModel.Vocabularies.Restrictions;
+using Vipr.Reader.OData.v4;
+using Xunit;
 
 namespace ODataReader.v4UnitTests
 {
@@ -224,7 +217,7 @@ namespace ODataReader.v4UnitTests
         {
             IEdmModel edmModel;
             IEnumerable<EdmError> errors;
-            if (!EdmxReader.TryParse(XmlReader.Create(new StringReader(ODataReader.v4UnitTests.Properties.Resources.OneNoteExampleEdmx)), out edmModel, out errors))
+            if (!CsdlReader.TryParse(XmlReader.Create(new StringReader(ODataReader.v4UnitTests.Properties.Resources.OneNoteExampleEdmx)), out edmModel, out errors))
             {
                 throw new InvalidOperationException("Failed to parse Edm model");
             }

--- a/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
+++ b/test/ODataReader.v4UnitTests/ODataReader.v4UnitTests.csproj
@@ -50,21 +50,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.OData.Client, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Client.6.11.0\lib\net40\Microsoft.OData.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.OData.Client, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Client.7.5.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Core.6.11.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Core.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.OData.Edm.6.11.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Spatial.6.11.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -132,7 +128,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Resources\template.edmx.xml">
       <SubType>Designer</SubType>
     </None>

--- a/test/ODataReader.v4UnitTests/packages.config
+++ b/test/ODataReader.v4UnitTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.3.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Client" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.11.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.11.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Client" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
**We'll only use this PR for review** since it contains the actual changes made to the v4 reader and ODatalibs that we care about. **We will not pull in this PR**.  **We will only pull in PR #140** since it contains all of these changes in this PR, plus the removed legacy projects that we no longer should maintain. Note that #140 passes CI. This PR doesn't pass CI since some of the changes we made affect some of the projects we are removing.

Update the models used in the generator templates: OdcmEntitySet and OdcmSingleton so that we can pass NavigationPropertyBindings to the generator templates.

Update the ODatalibs from 6.11.0 to latest (7.5.0). In addition to the support for NavigationPropertyBindings, we should get much better support for additions to the OData spec since 3.5 years ago. This required minor refactoring.
http://odata.github.io/odata.net/#06-21-Multi-Binding
http://odata.github.io/odata.net/#ODL-7.0.0
OData/odata.net#632

Fix failing unit tests after update.

I've used this update with the generator and was able to successfully use the NavigationBindingProperties in the template. This affects the .Net, Java, and Android client libraries.